### PR TITLE
Remove copy command for cargo audit config file

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -28,7 +28,6 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - run: cp -r .github/workflows/.cargo .cargo
       - uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We're not using this for now, and we can add it back later if we end up needing to use this for the time stuff.