### PR TITLE
Remove trace-tools from dev-dependencies of proc macro crate

### DIFF
--- a/trace-tools/trace-tools-attributes/Cargo.toml
+++ b/trace-tools/trace-tools-attributes/Cargo.toml
@@ -18,9 +18,3 @@ proc-macro = true
 proc-macro2 = { version = "1.0.28", default-features = false }
 quote = { version = "1.0.9", default-features = false }
 syn = { version = "1.0.75", default-features = false, features = [ "full", "extra-traits", "parsing", "printing", "derive", "proc-macro", "clone-impls" ] }
-
-[dev-dependencies]
-trace-tools = { version = "0.1.0", path = "../trace-tools", default-features = false }
-
-[package.metadata.cargo-udeps.ignore]
-development = [ "trace-tools" ]

--- a/trace-tools/trace-tools-attributes/src/lib.rs
+++ b/trace-tools/trace-tools-attributes/src/lib.rs
@@ -29,7 +29,7 @@ use syn::{
 /// # Examples
 ///
 /// A future or function can be wrapped in a `tracing` span with the following:
-/// ```rust
+/// ```ignore
 /// use trace_tools::observe;
 ///
 /// #[observe]


### PR DESCRIPTION
Removes `trace-tools` from the dev-dependencies of `trace-tools-attributes`, so crates.io is happy without the cyclic dependency. The only place it was required was in a documentation example, so this has been ignored (the example shouldn't need to change any time soon, so there shouldn't be any risk of it becoming outdated).