### PR TITLE
Minor fixes for the packable crates

### DIFF
--- a/packable/packable-derive-test/Cargo.toml
+++ b/packable/packable-derive-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packable-derive-test"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Test suite for the `packable-derive` crate."
@@ -16,7 +16,7 @@ name = "tests"
 path = "tests/lib.rs"
 
 [dev-dependencies]
-packable = { version = "=0.2.0", path = "../packable", default-features = false }
+packable = { version = "=0.2.1", path = "../packable", default-features = false }
 
 rustversion = { version = "1.0.5", default-features = false }
 trybuild = { version = "1.0.50", default-features = false, features = [ "diff" ] }

--- a/packable/packable-derive-test/Cargo.toml
+++ b/packable/packable-derive-test/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/iotaledger/common-rs"
 license = "Apache-2.0"
 publish = false
-keywords = [ "iota", "serialization", "framework", "packable" ]
+keywords = [ "binary", "no_std", "serialization", "packable" ]
 homepage = "https://www.iota.org"
 
 [[test]]

--- a/packable/packable-derive/Cargo.toml
+++ b/packable/packable-derive/Cargo.toml
@@ -7,7 +7,7 @@ description = "Derive macro for the `packable` crate."
 readme = "README.md"
 repository = "https://github.com/iotaledger/common-rs"
 license = "Apache-2.0"
-keywords = [ "iota", "serialization", "framework", "packable" ]
+keywords = [ "binary", "no_std", "serialization", "packable" ]
 homepage = "https://www.iota.org"
 
 [lib]

--- a/packable/packable-derive/Cargo.toml
+++ b/packable/packable-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packable-derive"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Derive macro for the `packable` crate."

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Make `String` packing more performant by using `Packer::pack_bytes` directly;
+- Fix documentation of `UnexpectedEOF` and `UnpackPrefixError`;
 
 ## 0.2.0 - 2022-02-09
 

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.X.X - 2022-XX-XX
 
+### Added
+
+- Make the `Error` implementation for `UnknownTagError` less restricted;
+
 ### Changed
 
 - Make `String` packing more performant by using `Packer::pack_bytes` directly;

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Make the `Error` implementation for `UnknownTagError` less restricted;
+- Implement `Error` for `UnpackError`;
 
 ### Changed
 

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.X.X - 2022-XX-XX
+## 0.2.1 - 2022-02-11
 
 ### Added
 

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Make the `Error` implementation for `UnknownTagError` less restricted;
 - Implement `Error` for `UnpackError`;
+- Document the `serde` and `primitive-types` features;
 
 ### Changed
 

--- a/packable/packable/Cargo.toml
+++ b/packable/packable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packable"
-version = "0.2.0"
+version = "0.2.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "A crate for packing and unpacking binary representations."
@@ -19,7 +19,7 @@ usize = [ ]
 autocfg = { version = "1.0.1", default-features = false }
 
 [dependencies]
-packable-derive = { version = "=0.2.0", path = "../packable-derive", default-features = false }
+packable-derive = { version = "=0.2.1", path = "../packable-derive", default-features = false }
 
 primitive-types = { version = "0.10.1", default-features = false, optional = true }
 serde = { version = "1.0.130", default-features = false, features = [ "derive", "std" ], optional = true }

--- a/packable/packable/README.md
+++ b/packable/packable/README.md
@@ -39,15 +39,25 @@ Check the `Packable` `impl` section for further information.
 
 ## Features
 
-### `std`
-
-This feature implements `Error` for all the error types provided by this crate.
-
 ### `io`
 
 This feature provides the types `IoPacker` and `IoUnpacker` which allow packing
 and unpacking from values whose types implement `Write` and `Read`
 respectively.
+
+### `primitive-types`
+
+This feature implements `Packable` for `U256` encoding its values as arrays of
+bytes in little-endian order.
+
+### `serde`
+
+This feature derives `Serialize` and `Deserialize` for the types provided in
+the `bounded` and `prefix` modules
+
+### `std`
+
+This feature implements `Error` for all the error types provided by this crate.
 
 ### `usize`
 

--- a/packable/packable/src/error.rs
+++ b/packable/packable/src/error.rs
@@ -110,7 +110,7 @@ impl Into<Infallible> for UnpackError<Infallible, Infallible> {
 pub struct UnknownTagError<T>(pub T);
 
 #[cfg(feature = "std")]
-impl<T> std::error::Error for UnknownTagError<T> where T: std::error::Error {}
+impl<T> std::error::Error for UnknownTagError<T> where T: fmt::Display + fmt::Debug {}
 
 impl<T> From<Infallible> for UnknownTagError<T> {
     fn from(err: Infallible) -> Self {

--- a/packable/packable/src/error.rs
+++ b/packable/packable/src/error.rs
@@ -96,6 +96,27 @@ impl<T> UnpackError<T, Infallible> {
     }
 }
 
+impl<T, U> fmt::Display for UnpackError<T, U>
+where
+    T: fmt::Display,
+    U: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Packable(err) => write!(f, "packable error while unpacking: {}", err),
+            Self::Unpacker(err) => write!(f, "unpacker error while unpacking: {}", err),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, U> std::error::Error for UnpackError<T, U>
+where
+    T: std::error::Error,
+    U: std::error::Error,
+{
+}
+
 /// We cannot provide a [`From`] implementation because [`Infallible`] is not from this crate.
 #[allow(clippy::from_over_into)]
 impl Into<Infallible> for UnpackError<Infallible, Infallible> {

--- a/packable/packable/src/error.rs
+++ b/packable/packable/src/error.rs
@@ -145,7 +145,7 @@ impl<T: fmt::Display> fmt::Display for UnknownTagError<T> {
     }
 }
 
-/// Error type to be raised when [`&[u8]`] does not have enough bytes to unpack something or when
+/// Error type to be raised when `&[u8]` does not have enough bytes to unpack something or when
 /// [`SlicePacker`]('crate::packer::SlicePacker') does not have enough space to pack something.
 #[derive(Debug)]
 pub struct UnexpectedEOF {

--- a/packable/packable/src/lib.rs
+++ b/packable/packable/src/lib.rs
@@ -41,16 +41,26 @@
 //!
 //! # Features
 //!
-//! ## `std`
-//!
-//! This feature implements [`Error`](std::error::Error) for all the error types provided by this
-//! crate.
-//!
 //! ## `io`
 //!
 //! This feature provides the types [`IoPacker`](packer::IoPacker) and
 //! [`IoUnpacker`](unpacker::IoUnpacker) which allow packing and unpacking from values whose types
 //! implement [`Write`](std::io::Write) and [`Read`](std::io::Read) respectively.
+//!
+//! ## `primitive-types`
+//!
+//! This feature implements [`Packable`] for [`U256`](primitive_types::U256) encoding its values as
+//! arrays of bytes in little-endian order.
+//!
+//! ## `serde`
+//!
+//! This feature derives [`Serialize`](serde::Serialize) and [`Deserialize`](serde::Deserialize)
+//! for the types provided in the [`mod@bounded`] and [`prefix`] modules
+//!
+//! ## `std`
+//!
+//! This feature implements [`Error`](std::error::Error) for all the error types provided by this
+//! crate.
 //!
 //! ## `usize`
 //!

--- a/packable/packable/src/packable/prefix.rs
+++ b/packable/packable/src/packable/prefix.rs
@@ -21,8 +21,7 @@ use core::{
     ops::{Deref, DerefMut, Range},
 };
 
-/// Semantic error raised while unpacking a dynamically-sized sequences that use a type different than `usize` for their
-/// length-prefix.
+/// Semantic error raised while unpacking dynamically-sized sequences.
 #[derive(Debug)]
 pub enum UnpackPrefixError<T, E> {
     /// Semantic error raised while unpacking an item of the sequence. Typically this is


### PR DESCRIPTION
This updates the `packable` version to `0.2.1`