### PR TITLE
(Packable) Pack and unpack byte buffers faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,65 @@ jobs:
           command: test
           args: --workspace --all-targets --all-features --release
 
+  miri:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crates: [
+          "packable",
+        ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set rust nightly version
+        run: echo "NIGHTLY_VERSION=$(curl https://rust-lang.github.io/rustup-components-history/x86_64-unknown-linux-gnu/miri)" >> $GITHUB_ENV
+
+      - name: Install rust nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-${{ env.NIGHTLY_VERSION }}
+          override: true
+          components: miri
+
+      - name: Cache cargo state
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-cargo
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin
+          key: ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}-build
+          restore-keys: |
+            ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}-
+            ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-${{ env.cache-name }}-
+            ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-
+            ubuntu-latest-
+
+      - name: Cache target dir
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-target
+        with:
+          path: |
+            target/
+          key: ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}-build
+          restore-keys: |
+            ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.toml') }}-
+            ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-${{ env.cache-name }}-
+            ubuntu-latest-nightly-${{ env.NIGHTLY_VERSION }}-
+            ubuntu-latest-
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: miri
+          args: test --release --all-features -p ${{ matrix.crates }}
+
   no_std:
     needs: build-and-test
     runs-on: ubuntu-latest

--- a/.license_template
+++ b/.license_template
@@ -1,0 +1,2 @@
+// Copyright {20\d{2}(-20\d{2})?} IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0

--- a/auth-helper/src/jwt.rs
+++ b/auth-helper/src/jwt.rs
@@ -172,11 +172,7 @@ impl std::fmt::Display for JsonWebToken {
 impl JsonWebToken {
     /// Creates a new JSON Web Token.
     pub fn new(claims: Claims, secret: &[u8]) -> Result<Self, Error> {
-        let token = encode(
-            &Header::default(),
-            &claims,
-            &EncodingKey::from_secret(secret),
-        )?;
+        let token = encode(&Header::default(), &claims, &EncodingKey::from_secret(secret))?;
 
         Ok(Self(token))
     }

--- a/auth-helper/tests/jwt.rs
+++ b/auth-helper/tests/jwt.rs
@@ -16,15 +16,16 @@ fn jwt_valid() {
 
     let jwt = jwt::JsonWebToken::new(claims, b"secret").unwrap();
 
-    assert!(jwt
-        .validate(
+    assert!(
+        jwt.validate(
             String::from("issuer"),
             String::from("subject"),
             String::from("audience"),
             false,
             b"secret",
         )
-        .is_ok());
+        .is_ok()
+    );
 }
 
 #[test]
@@ -38,21 +39,18 @@ fn jwt_to_str_from_str_valid() {
     .build()
     .unwrap();
 
-    let jwt = jwt::JsonWebToken::from(
-        jwt::JsonWebToken::new(claims, b"secret")
-            .unwrap()
-            .to_string(),
-    );
+    let jwt = jwt::JsonWebToken::from(jwt::JsonWebToken::new(claims, b"secret").unwrap().to_string());
 
-    assert!(jwt
-        .validate(
+    assert!(
+        jwt.validate(
             String::from("issuer"),
             String::from("subject"),
             String::from("audience"),
             false,
             b"secret",
         )
-        .is_ok());
+        .is_ok()
+    );
 }
 
 #[test]
@@ -68,15 +66,16 @@ fn jwt_invalid_issuer() {
 
     let jwt = jwt::JsonWebToken::new(claims, b"secret").unwrap();
 
-    assert!(jwt
-        .validate(
+    assert!(
+        jwt.validate(
             String::from("Issuer"),
             String::from("subject"),
             String::from("audience"),
             false,
             b"secret",
         )
-        .is_err());
+        .is_err()
+    );
 }
 
 #[test]
@@ -92,15 +91,16 @@ fn jwt_invalid_subject() {
 
     let jwt = jwt::JsonWebToken::new(claims, b"secret").unwrap();
 
-    assert!(jwt
-        .validate(
+    assert!(
+        jwt.validate(
             String::from("issuer"),
             String::from("Subject"),
             String::from("audience"),
             false,
             b"secret",
         )
-        .is_err());
+        .is_err()
+    );
 }
 
 #[test]
@@ -116,15 +116,16 @@ fn jwt_invalid_audience() {
 
     let jwt = jwt::JsonWebToken::new(claims, b"secret").unwrap();
 
-    assert!(jwt
-        .validate(
+    assert!(
+        jwt.validate(
             String::from("issuer"),
             String::from("subject"),
             String::from("Audience"),
             false,
             b"secret",
         )
-        .is_err());
+        .is_err()
+    );
 }
 
 #[test]
@@ -140,15 +141,16 @@ fn jwt_invalid_secret() {
 
     let jwt = jwt::JsonWebToken::new(claims, b"secret").unwrap();
 
-    assert!(jwt
-        .validate(
+    assert!(
+        jwt.validate(
             String::from("issuer"),
             String::from("subject"),
             String::from("audience"),
             false,
             b"Secret",
         )
-        .is_err());
+        .is_err()
+    );
 }
 
 #[test]
@@ -166,13 +168,14 @@ fn jwt_invalid_expired() {
 
     std::thread::sleep(std::time::Duration::from_secs(1));
 
-    assert!(jwt
-        .validate(
+    assert!(
+        jwt.validate(
             String::from("issuer"),
             String::from("subject"),
             String::from("audience"),
             true,
             b"secret",
         )
-        .is_err());
+        .is_err()
+    );
 }

--- a/fern-logger/src/config.rs
+++ b/fern-logger/src/config.rs
@@ -58,24 +58,14 @@ impl LoggerOutputConfigBuilder {
     /// Sets a collection of filters of a logger output.
     /// A message is logged only if one of the filters is part of the log's metadata target.
     pub fn target_filters(mut self, target_filters: &[&str]) -> Self {
-        self.target_filters = Some(
-            target_filters
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>(),
-        );
+        self.target_filters = Some(target_filters.iter().map(ToString::to_string).collect::<Vec<_>>());
         self
     }
 
     /// Sets a collection of exclusions of a logger output.
     /// A message is logged only if one of the exclusions is *not* part of the log's metadata target.
     pub fn target_exclusions(mut self, target_exclusions: &[&str]) -> Self {
-        self.target_exclusions = Some(
-            target_exclusions
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>(),
-        );
+        self.target_exclusions = Some(target_exclusions.iter().map(ToString::to_string).collect::<Vec<_>>());
         self
     }
 
@@ -188,13 +178,10 @@ impl LoggerConfigBuilder {
         let name = name.into();
 
         if let Some(outputs) = self.outputs.as_deref_mut() {
-            if let Some(stdout) = outputs
-                .iter_mut()
-                .find(|output| match output.name.as_ref() {
-                    Some(output_name) => output_name[..] == name,
-                    None => false,
-                })
-            {
+            if let Some(stdout) = outputs.iter_mut().find(|output| match output.name.as_ref() {
+                Some(output_name) => output_name[..] == name,
+                None => false,
+            }) {
                 stdout.level_filter.replace(level);
             }
         }

--- a/fern-logger/src/lib.rs
+++ b/fern-logger/src/lib.rs
@@ -5,9 +5,7 @@
 
 mod config;
 
-pub use config::{
-    LoggerConfig, LoggerConfigBuilder, LoggerOutputConfig, LoggerOutputConfigBuilder,
-};
+pub use config::{LoggerConfig, LoggerConfigBuilder, LoggerOutputConfig, LoggerOutputConfigBuilder};
 
 use fern::{
     colors::{Color, ColoredLevelConfig},

--- a/packable/packable-derive-test/src/lib.rs
+++ b/packable/packable-derive-test/src/lib.rs
@@ -1,1 +1,2 @@
-
+// Copyright 2021-2022 IOTA Stiftung
+// SPDX-License-Identifier: Apache-2.0

--- a/packable/packable-derive/src/enum_info.rs
+++ b/packable/packable-derive/src/enum_info.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    parse::filter_attrs, tag_type_info::TagTypeInfo, unpack_error_info::UnpackErrorInfo,
-    variant_info::VariantInfo,
+    parse::filter_attrs, tag_type_info::TagTypeInfo, unpack_error_info::UnpackErrorInfo, variant_info::VariantInfo,
 };
 
 use syn::{parse_quote, Attribute, DataEnum, Ident, Result, Type};
@@ -15,12 +14,7 @@ pub(crate) struct EnumInfo {
 }
 
 impl EnumInfo {
-    pub(crate) fn new(
-        ident: Ident,
-        data: DataEnum,
-        attrs: &[Attribute],
-        crate_name: &Ident,
-    ) -> Result<Self> {
+    pub(crate) fn new(ident: Ident, data: DataEnum, attrs: &[Attribute], crate_name: &Ident) -> Result<Self> {
         let repr_type = attrs
             .iter()
             .find(|attr| attr.path.is_ident("repr"))

--- a/packable/packable-derive/src/field_info.rs
+++ b/packable/packable-derive/src/field_info.rs
@@ -30,11 +30,7 @@ pub(crate) struct FieldInfo {
 }
 
 impl FieldInfo {
-    pub(crate) fn new(
-        field: &Field,
-        default_unpack_error_with: &Expr,
-        index: usize,
-    ) -> Result<Self> {
+    pub(crate) fn new(field: &Field, default_unpack_error_with: &Expr, index: usize) -> Result<Self> {
         let pattern_ident = match &field.ident {
             Some(ident) => IdentOrIndex::Ident(ident.clone()),
             None => IdentOrIndex::Index(Index {
@@ -71,8 +67,7 @@ impl FieldInfo {
         }
 
         Ok(Self {
-            unpack_error_with: unpack_error_with_opt
-                .unwrap_or_else(|| default_unpack_error_with.clone()),
+            unpack_error_with: unpack_error_with_opt.unwrap_or_else(|| default_unpack_error_with.clone()),
             verify_with: verify_with_opt,
             ident,
             pattern_ident,

--- a/packable/packable-derive/src/lib.rs
+++ b/packable/packable-derive/src/lib.rs
@@ -28,11 +28,10 @@ use syn::{parse_macro_input, Ident};
 pub fn packable(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
 
-    let crate_string =
-        match crate_name("packable").expect("packable should be present in `Cargo.toml`") {
-            FoundCrate::Itself => "packable_crate".to_owned(),
-            FoundCrate::Name(name) => name,
-        };
+    let crate_string = match crate_name("packable").expect("packable should be present in `Cargo.toml`") {
+        FoundCrate::Itself => "packable_crate".to_owned(),
+        FoundCrate::Name(name) => name,
+    };
 
     match TraitImpl::new(input, Ident::new(&crate_string, Span::call_site())) {
         Ok(trait_impl) => trait_impl.into_token_stream().into(),

--- a/packable/packable-derive/src/parse.rs
+++ b/packable/packable-derive/src/parse.rs
@@ -32,10 +32,7 @@ pub(crate) fn parse_kv<T: Parse>(ident: &'static str, stream: ParseStream) -> Re
     }
 }
 
-pub(crate) fn parse_kv_after_comma<T: Parse>(
-    ident: &'static str,
-    stream: ParseStream,
-) -> Result<Option<T>> {
+pub(crate) fn parse_kv_after_comma<T: Parse>(ident: &'static str, stream: ParseStream) -> Result<Option<T>> {
     if stream.is_empty() {
         return Ok(None);
     }
@@ -60,9 +57,6 @@ fn validate_ident(ident: &Ident) -> Result<()> {
     if KNOWN_IDENTS.iter().any(|known_ident| ident == known_ident) {
         Ok(())
     } else {
-        Err(Error::new(
-            ident.span(),
-            format!("Unknown identifier `{}`.", ident),
-        ))
+        Err(Error::new(ident.span(), format!("Unknown identifier `{}`.", ident)))
     }
 }

--- a/packable/packable-derive/src/record_info.rs
+++ b/packable/packable-derive/src/record_info.rs
@@ -15,11 +15,7 @@ pub(crate) struct RecordInfo {
 }
 
 impl RecordInfo {
-    pub(crate) fn new(
-        path: Path,
-        fields: &Fields,
-        default_unpack_error_with: &Expr,
-    ) -> Result<Self> {
+    pub(crate) fn new(path: Path, fields: &Fields, default_unpack_error_with: &Expr) -> Result<Self> {
         let len = fields.len();
         let mut fields_unpack_error_with = Vec::with_capacity(len);
         let mut fields_verify_with = Vec::with_capacity(len);

--- a/packable/packable-derive/src/struct_info.rs
+++ b/packable/packable-derive/src/struct_info.rs
@@ -11,12 +11,7 @@ pub(crate) struct StructInfo {
 }
 
 impl StructInfo {
-    pub(crate) fn new(
-        path: Path,
-        fields: &Fields,
-        attrs: &[Attribute],
-        crate_name: &Ident,
-    ) -> Result<Self> {
+    pub(crate) fn new(path: Path, fields: &Fields, attrs: &[Attribute], crate_name: &Ident) -> Result<Self> {
         let filtered_attrs = filter_attrs(attrs);
 
         let unpack_error = UnpackErrorInfo::new(filtered_attrs, || match fields.iter().next() {
@@ -26,9 +21,6 @@ impl StructInfo {
 
         let inner = RecordInfo::new(path, fields, &unpack_error.with)?;
 
-        Ok(Self {
-            unpack_error,
-            inner,
-        })
+        Ok(Self { unpack_error, inner })
     }
 }

--- a/packable/packable-derive/src/trait_impl.rs
+++ b/packable/packable-derive/src/trait_impl.rs
@@ -23,20 +23,11 @@ impl TraitImpl {
     pub(crate) fn new(input: DeriveInput, crate_name: Ident) -> syn::Result<Self> {
         match input.data {
             Data::Struct(data) => {
-                let info = StructInfo::new(
-                    input.ident.clone().into(),
-                    &data.fields,
-                    &input.attrs,
-                    &crate_name,
-                )?;
+                let info = StructInfo::new(input.ident.clone().into(), &data.fields, &input.attrs, &crate_name)?;
 
                 let unpack_error = info.unpack_error.unpack_error.clone().into_token_stream();
 
-                let Fragments {
-                    pattern,
-                    pack,
-                    unpack,
-                }: Fragments = Fragments::new(info.inner, &crate_name);
+                let Fragments { pattern, pack, unpack }: Fragments = Fragments::new(info.inner, &crate_name);
 
                 Ok(Self {
                     ident: input.ident,
@@ -67,16 +58,10 @@ impl TraitImpl {
                 let mut tag_decls = Vec::with_capacity(len);
                 let mut tag_variants_and_idents = Vec::with_capacity(len);
 
-                for (index, VariantInfo { tag, inner }) in
-                    info.variants_info.into_iter().enumerate()
-                {
+                for (index, VariantInfo { tag, inner }) in info.variants_info.into_iter().enumerate() {
                     let variant_ident = inner.path.segments.last().unwrap().clone();
 
-                    let Fragments {
-                        pattern,
-                        pack,
-                        unpack,
-                    } = Fragments::new(inner, &crate_name);
+                    let Fragments { pattern, pack, unpack } = Fragments::new(inner, &crate_name);
 
                     // @pvdrz: The span here is very important, otherwise the compiler won't detect
                     // unreachable patterns in the generated code for some reason. I think this is related

--- a/packable/packable-derive/src/unpack_error_info.rs
+++ b/packable/packable-derive/src/unpack_error_info.rs
@@ -32,8 +32,8 @@ impl UnpackErrorInfo {
         default_unpack_error: impl FnOnce() -> syn::Type,
     ) -> Result<Self> {
         for attr in filtered_attrs {
-            let opt_info = attr.parse_args_with(|stream: ParseStream| {
-                match parse_kv::<Type>("unpack_error", stream)? {
+            let opt_info =
+                attr.parse_args_with(|stream: ParseStream| match parse_kv::<Type>("unpack_error", stream)? {
                     Some(Type(unpack_error)) => {
                         let with = match parse_kv_after_comma("with", stream)? {
                             Some(with) => with,
@@ -46,8 +46,7 @@ impl UnpackErrorInfo {
                         skip_stream(stream)?;
                         Ok(None)
                     }
-                }
-            })?;
+                })?;
 
             if let Some(info) = opt_info {
                 return Ok(info);

--- a/packable/packable-derive/src/variant_info.rs
+++ b/packable/packable-derive/src/variant_info.rs
@@ -24,10 +24,7 @@ impl Parse for ExprTag {
         match ExprLit::parse(input) {
             Ok(lit) => Ok(Self::Lit(lit)),
             Err(_) => Ok(Self::Path(ExprPath::parse(input).map_err(|err| {
-                Error::new(
-                    err.span(),
-                    "Tags for variants can only be literal or path expressions.",
-                )
+                Error::new(err.span(), "Tags for variants can only be literal or path expressions.")
             })?)),
         }
     }
@@ -48,17 +45,11 @@ pub(crate) struct VariantInfo {
 }
 
 impl VariantInfo {
-    pub(crate) fn new(
-        variant: &Variant,
-        enum_ident: &syn::Ident,
-        default_unpack_error_with: &Expr,
-    ) -> Result<Self> {
+    pub(crate) fn new(variant: &Variant, enum_ident: &syn::Ident, default_unpack_error_with: &Expr) -> Result<Self> {
         let variant_ident = variant.ident.clone();
 
         for attr in filter_attrs(&variant.attrs) {
-            if let Some(tag) =
-                attr.parse_args_with(|stream: ParseStream| parse_kv("tag", stream))?
-            {
+            if let Some(tag) = attr.parse_args_with(|stream: ParseStream| parse_kv("tag", stream))? {
                 return Ok(Self {
                     tag,
                     inner: RecordInfo::new(

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -22,11 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.X.X - 2022-XX-XX
 
-## 0.2.1 - 2022-02-11
-
 ### Changed
 
 - Make byte buffers packing and unpacking more performant.
+
+## 0.2.1 - 2022-02-11
 
 ### Added
 

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Make byte buffers packing and unpacking more performant.
+- Make byte buffers packing and unpacking more performant;
 
 ## 0.2.1 - 2022-02-11
 

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -19,7 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+
+## 0.X.X - 2022-XX-XX
+
 ## 0.2.1 - 2022-02-11
+
+### Changed
+
+- Make byte buffers packing and unpacking more performant.
 
 ### Added
 

--- a/packable/packable/src/error.rs
+++ b/packable/packable/src/error.rs
@@ -160,10 +160,6 @@ impl std::error::Error for UnexpectedEOF {}
 
 impl fmt::Display for UnexpectedEOF {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "not enough bytes, required {} but had {}",
-            self.required, self.had
-        )
+        write!(f, "not enough bytes, required {} but had {}", self.required, self.had)
     }
 }

--- a/packable/packable/src/packable/array.rs
+++ b/packable/packable/src/packable/array.rs
@@ -3,14 +3,21 @@
 
 use crate::{error::UnpackError, packer::Packer, unpacker::Unpacker, Packable};
 
+use core::any::TypeId;
 use core::mem::MaybeUninit;
 
 impl<T: Packable, const N: usize> Packable for [T; N] {
     type UnpackError = T::UnpackError;
 
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {
-        for item in self.iter() {
-            item.pack(packer)?;
+        if TypeId::of::<T>() == TypeId::of::<u8>() {
+            // Safety: `Self` is identical to `[u8; N]`.
+            let bytes = unsafe { core::mem::transmute::<&Self, &[u8; N]>(self) };
+            packer.pack_bytes(bytes)?;
+        } else {
+            for item in self.iter() {
+                item.pack(packer)?;
+            }
         }
 
         Ok(())
@@ -19,22 +26,29 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
     fn unpack<U: Unpacker, const VERIFY: bool>(
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        // Safety: an uninitialized array of [`MaybeUninit`]s is safe to be considered initialized.
-        // FIXME: replace with [`MaybeUninit::uninit_array`] when stabilized.
-        let mut array = unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() };
+        if TypeId::of::<T>() == TypeId::of::<u8>() {
+            let mut bytes = [0u8; N];
+            unpacker.unpack_bytes(&mut bytes)?;
+            // Safety: `Self` is identical to `[u8; N]`.
+            Ok(unsafe { (&bytes as *const [u8; N] as *const Self).read() })
+        } else {
+            // Safety: an uninitialized array of [`MaybeUninit`]s is safe to be considered initialized.
+            // FIXME: replace with [`MaybeUninit::uninit_array`] when stabilized.
+            let mut array = unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() };
 
-        for item in array.iter_mut() {
-            let unpacked = T::unpack::<_, VERIFY>(unpacker)?;
+            for item in array.iter_mut() {
+                let unpacked = T::unpack::<_, VERIFY>(unpacker)?;
 
-            // Safety: each `item` is only visited once so we are never overwriting nor dropping values that are already
-            // initialized.
-            unsafe {
-                item.as_mut_ptr().write(unpacked);
+                // Safety: each `item` is only visited once so we are never overwriting nor dropping values that are already
+                // initialized.
+                unsafe {
+                    item.as_mut_ptr().write(unpacked);
+                }
             }
-        }
 
-        // Safety: We traversed the whole array and initialized every item.
-        // FIXME: replace with [`MaybeUninit::array_assume_init`] when stabilized.
-        Ok(unsafe { (&array as *const [MaybeUninit<T>; N] as *const Self).read() })
+            // Safety: We traversed the whole array and initialized every item.
+            // FIXME: replace with [`MaybeUninit::array_assume_init`] when stabilized.
+            Ok(unsafe { (&array as *const [MaybeUninit<T>; N] as *const Self).read() })
+        }
     }
 }

--- a/packable/packable/src/packable/array.rs
+++ b/packable/packable/src/packable/array.rs
@@ -3,8 +3,7 @@
 
 use crate::{error::UnpackError, packer::Packer, unpacker::Unpacker, Packable};
 
-use core::any::TypeId;
-use core::mem::MaybeUninit;
+use core::{any::TypeId, mem::MaybeUninit};
 
 impl<T: Packable, const N: usize> Packable for [T; N] {
     type UnpackError = T::UnpackError;
@@ -39,8 +38,8 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
             for item in array.iter_mut() {
                 let unpacked = T::unpack::<_, VERIFY>(unpacker)?;
 
-                // Safety: each `item` is only visited once so we are never overwriting nor dropping values that are already
-                // initialized.
+                // Safety: each `item` is only visited once so we are never overwriting nor dropping values that are
+                // already initialized.
                 unsafe {
                     item.as_mut_ptr().write(unpacked);
                 }

--- a/packable/packable/src/packable/box.rs
+++ b/packable/packable/src/packable/box.rs
@@ -6,6 +6,10 @@ extern crate alloc;
 use crate::{error::UnpackError, packer::Packer, unpacker::Unpacker, Packable};
 
 use alloc::boxed::Box;
+#[cfg(feature = "usize")]
+use alloc::{vec, vec::Vec};
+#[cfg(feature = "usize")]
+use core::any::TypeId;
 use core::ops::Deref;
 
 impl<T: Packable> Packable for Box<T> {
@@ -33,8 +37,14 @@ impl<T: Packable> Packable for Box<[T]> {
         // This cast is fine because we know `usize` is not larger than `64` bits.
         (self.len() as u64).pack(packer)?;
 
-        for item in self.iter() {
-            item.pack(packer)?;
+        if TypeId::of::<T>() == TypeId::of::<u8>() {
+            // Safety: `Self` is identical to `Box<[u8]>`.
+            let bytes = unsafe { core::mem::transmute::<&Self, &Box<[u8]>>(self) };
+            packer.pack_bytes(bytes)?;
+        } else {
+            for item in self.iter() {
+                item.pack(packer)?;
+            }
         }
 
         Ok(())
@@ -50,13 +60,20 @@ impl<T: Packable> Packable for Box<[T]> {
             .try_into()
             .map_err(|err| UnpackError::Packable(Self::UnpackError::Prefix(err)))?;
 
-        let mut vec = alloc::vec::Vec::with_capacity(len);
+        if TypeId::of::<T>() == TypeId::of::<u8>() {
+            let mut bytes = vec![0u8; len].into_boxed_slice();
+            unpacker.unpack_bytes(&mut bytes)?;
+            // Safety: `Self` is identical to `Box<[u8]>`.
+            Ok(unsafe { core::mem::transmute::<Box<[u8]>, Self>(bytes) })
+        } else {
+            let mut vec = Vec::with_capacity(len);
 
-        for _ in 0..len {
-            let item = T::unpack::<_, VERIFY>(unpacker).coerce()?;
-            vec.push(item);
+            for _ in 0..len {
+                let item = T::unpack::<_, VERIFY>(unpacker).coerce()?;
+                vec.push(item);
+            }
+
+            Ok(vec.into_boxed_slice())
         }
-
-        Ok(vec.into_boxed_slice())
     }
 }

--- a/packable/packable/src/packable/box.rs
+++ b/packable/packable/src/packable/box.rs
@@ -29,8 +29,7 @@ impl<T: Packable> Packable for Box<T> {
 
 #[cfg(feature = "usize")]
 impl<T: Packable> Packable for Box<[T]> {
-    type UnpackError =
-        crate::prefix::UnpackPrefixError<T::UnpackError, <usize as Packable>::UnpackError>;
+    type UnpackError = crate::prefix::UnpackPrefixError<T::UnpackError, <usize as Packable>::UnpackError>;
 
     #[inline(always)]
     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error> {

--- a/packable/packable/src/packable/mod.rs
+++ b/packable/packable/src/packable/mod.rs
@@ -169,7 +169,7 @@ use core::{convert::AsRef, fmt::Debug};
 /// where `F` is the type of the field being verified, `P` is the type of the `struct` or `enum`
 /// and `VERIFY` is the same constant parameter used inside `Packable::unpack`. This verification
 /// function will be run immediately after unpacking the field.
-pub trait Packable: Sized {
+pub trait Packable: Sized + 'static {
     /// The error type that can be returned if some semantic error occurs while unpacking.
     ///
     /// It is recommended to use [`Infallible`](core::convert::Infallible) if this kind of error is impossible or

--- a/packable/packable/src/packable/num.rs
+++ b/packable/packable/src/packable/num.rs
@@ -61,8 +61,7 @@ impl Packable for usize {
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
-        Self::try_from(u64::unpack::<_, VERIFY>(unpacker).infallible()?)
-            .map_err(UnpackError::Packable)
+        Self::try_from(u64::unpack::<_, VERIFY>(unpacker).infallible()?).map_err(UnpackError::Packable)
     }
 }
 
@@ -78,7 +77,6 @@ impl Packable for isize {
         unpacker: &mut U,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
-        Self::try_from(i64::unpack::<_, VERIFY>(unpacker).infallible()?)
-            .map_err(UnpackError::Packable)
+        Self::try_from(i64::unpack::<_, VERIFY>(unpacker).infallible()?).map_err(UnpackError::Packable)
     }
 }

--- a/packable/packable/src/packable/vec.rs
+++ b/packable/packable/src/packable/vec.rs
@@ -11,8 +11,7 @@ use crate::{
     Packable,
 };
 
-use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 use core::any::TypeId;
 
 impl<T> Packable for Vec<T>

--- a/packable/packable/src/packable/vec.rs
+++ b/packable/packable/src/packable/vec.rs
@@ -11,7 +11,9 @@ use crate::{
     Packable,
 };
 
+use alloc::vec;
 use alloc::vec::Vec;
+use core::any::TypeId;
 
 impl<T> Packable for Vec<T>
 where
@@ -23,8 +25,14 @@ where
         // This cast is fine because we know `usize` is not larger than `64` bits.
         (self.len() as u64).pack(packer)?;
 
-        for item in self.iter() {
-            item.pack(packer)?;
+        if TypeId::of::<T>() == TypeId::of::<u8>() {
+            // Safety: `Self` is identical to `Vec<u8>`.
+            let bytes = unsafe { core::mem::transmute::<&Self, &Vec<u8>>(self) };
+            packer.pack_bytes(bytes)?;
+        } else {
+            for item in self.iter() {
+                item.pack(packer)?;
+            }
         }
 
         Ok(())
@@ -38,13 +46,20 @@ where
             .try_into()
             .map_err(|err| UnpackError::Packable(UnpackPrefixError::Prefix(err)))?;
 
-        let mut vec = Vec::with_capacity(len);
+        if TypeId::of::<T>() == TypeId::of::<u8>() {
+            let mut bytes = vec![0u8; len];
+            unpacker.unpack_bytes(&mut bytes)?;
+            // Safety: `Self` is identical to `Vec<u8>`.
+            Ok(unsafe { core::mem::transmute::<Vec<u8>, Self>(bytes) })
+        } else {
+            let mut vec = Vec::with_capacity(len);
 
-        for _ in 0..len {
-            let item = T::unpack::<_, VERIFY>(unpacker).coerce()?;
-            vec.push(item);
+            for _ in 0..len {
+                let item = T::unpack::<_, VERIFY>(unpacker).coerce()?;
+                vec.push(item);
+            }
+
+            Ok(vec)
         }
-
-        Ok(vec)
     }
 }

--- a/packable/packable/tests/bool.rs
+++ b/packable/packable/tests/bool.rs
@@ -7,14 +7,8 @@ use packable::{Packable, PackableExt};
 
 #[test]
 fn packable_bool() {
-    assert_eq!(
-        common::generic_test(&false).0.len(),
-        core::mem::size_of::<u8>()
-    );
-    assert_eq!(
-        common::generic_test(&true).0.len(),
-        core::mem::size_of::<u8>()
-    );
+    assert_eq!(common::generic_test(&false).0.len(), core::mem::size_of::<u8>());
+    assert_eq!(common::generic_test(&true).0.len(), core::mem::size_of::<u8>());
 }
 
 #[test]

--- a/packable/packable/tests/bounded.rs
+++ b/packable/packable/tests/bounded.rs
@@ -5,8 +5,8 @@ mod common;
 
 use packable::{
     bounded::{
-        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32,
-        InvalidBoundedU64, InvalidBoundedU8,
+        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32, InvalidBoundedU64,
+        InvalidBoundedU8,
     },
     error::UnpackError,
     PackableExt,

--- a/packable/packable/tests/boxed_slice.rs
+++ b/packable/packable/tests/boxed_slice.rs
@@ -6,9 +6,7 @@ mod common;
 #[test]
 fn packable_boxed_slice() {
     assert_eq!(
-        common::generic_test(&vec![Some(0u32), None].into_boxed_slice())
-            .0
-            .len(),
+        common::generic_test(&vec![Some(0u32), None].into_boxed_slice()).0.len(),
         core::mem::size_of::<u64>()
             + (core::mem::size_of::<u8>() + core::mem::size_of::<u32>())
             + core::mem::size_of::<u8>()

--- a/packable/packable/tests/boxed_slice_prefix.rs
+++ b/packable/packable/tests/boxed_slice_prefix.rs
@@ -5,8 +5,8 @@ mod common;
 
 use packable::{
     bounded::{
-        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32,
-        InvalidBoundedU64, InvalidBoundedU8, TryIntoBoundedU32Error,
+        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32, InvalidBoundedU64,
+        InvalidBoundedU8, TryIntoBoundedU32Error,
     },
     error::UnpackError,
     prefix::{BoxedSlicePrefix, UnpackPrefixError},
@@ -35,10 +35,7 @@ macro_rules! impl_packable_test_for_boxed_slice_prefix {
         fn $packable_boxed_slice_prefix() {
             assert_eq!(
                 common::generic_test(
-                    &<BoxedSlicePrefix<Option<u32>, $ty>>::try_from(
-                        vec![Some(0u32), None].into_boxed_slice()
-                    )
-                    .unwrap()
+                    &<BoxedSlicePrefix<Option<u32>, $ty>>::try_from(vec![Some(0u32), None].into_boxed_slice()).unwrap()
                 )
                 .0
                 .len(),
@@ -82,9 +79,7 @@ macro_rules! impl_packable_test_for_bounded_boxed_slice_prefix {
 
             assert!(matches!(
                 prefixed,
-                Err(UnpackError::Packable(UnpackPrefixError::Prefix($err(
-                    LEN_AS_TY
-                )))),
+                Err(UnpackError::Packable(UnpackPrefixError::Prefix($err(LEN_AS_TY)))),
             ));
         }
     };

--- a/packable/packable/tests/vec_prefix.rs
+++ b/packable/packable/tests/vec_prefix.rs
@@ -5,8 +5,8 @@ mod common;
 
 use packable::{
     bounded::{
-        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32,
-        InvalidBoundedU64, InvalidBoundedU8, TryIntoBoundedU32Error,
+        BoundedU16, BoundedU32, BoundedU64, BoundedU8, InvalidBoundedU16, InvalidBoundedU32, InvalidBoundedU64,
+        InvalidBoundedU8, TryIntoBoundedU32Error,
     },
     error::UnpackError,
     prefix::{UnpackPrefixError, VecPrefix},
@@ -34,11 +34,9 @@ macro_rules! impl_packable_test_for_vec_prefix {
         #[test]
         fn $packable_vec_prefix() {
             assert_eq!(
-                common::generic_test(
-                    &<VecPrefix<Option<u32>, $ty>>::try_from(vec![Some(0u32), None]).unwrap()
-                )
-                .0
-                .len(),
+                common::generic_test(&<VecPrefix<Option<u32>, $ty>>::try_from(vec![Some(0u32), None]).unwrap())
+                    .0
+                    .len(),
                 core::mem::size_of::<$ty>()
                     + (core::mem::size_of::<u8>() + core::mem::size_of::<u32>())
                     + core::mem::size_of::<u8>()
@@ -53,11 +51,7 @@ macro_rules! impl_packable_test_for_bounded_vec_prefix {
         fn $packable_vec_prefix() {
             assert_eq!(
                 common::generic_test(
-                    &<VecPrefix<Option<u32>, $bounded<$min, $max>>>::try_from(vec![
-                        Some(0u32),
-                        None
-                    ])
-                    .unwrap()
+                    &<VecPrefix<Option<u32>, $bounded<$min, $max>>>::try_from(vec![Some(0u32), None]).unwrap()
                 )
                 .0
                 .len(),
@@ -80,34 +74,16 @@ macro_rules! impl_packable_test_for_bounded_vec_prefix {
 
             assert!(matches!(
                 prefixed,
-                Err(UnpackError::Packable(UnpackPrefixError::Prefix($err(
-                    LEN_AS_TY
-                )))),
+                Err(UnpackError::Packable(UnpackPrefixError::Prefix($err(LEN_AS_TY)))),
             ));
         }
     };
 }
 
-impl_packable_test_for_vec_prefix!(
-    packable_vec_prefix_u8,
-    packable_vec_prefix_invalid_length_u8,
-    u8
-);
-impl_packable_test_for_vec_prefix!(
-    packable_vec_prefix_u16,
-    packable_vec_prefix_invalid_length_u16,
-    u16
-);
-impl_packable_test_for_vec_prefix!(
-    packable_vec_prefix_u32,
-    packable_vec_prefix_invalid_length_u32,
-    u32
-);
-impl_packable_test_for_vec_prefix!(
-    packable_vec_prefix_u64,
-    packable_vec_prefix_invalid_length_u64,
-    u64
-);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u8, packable_vec_prefix_invalid_length_u8, u8);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u16, packable_vec_prefix_invalid_length_u16, u16);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u32, packable_vec_prefix_invalid_length_u32, u32);
+impl_packable_test_for_vec_prefix!(packable_vec_prefix_u64, packable_vec_prefix_invalid_length_u64, u64);
 
 impl_packable_test_for_bounded_vec_prefix!(
     packable_vec_prefix_bounded_u8,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,7 @@
 version = "Two"
 comment_width = 120
 format_code_in_doc_comments = true
+license_template_path = ".license_template"
 max_width = 120
 imports_granularity = "Crate"
 normalize_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,8 @@
+version = "Two"
+comment_width = 120
+format_code_in_doc_comments = true
+max_width = 120
+imports_granularity = "Crate"
+normalize_comments = true
+normalize_doc_attributes = true
+wrap_comments = true

--- a/time-helper/src/lib.rs
+++ b/time-helper/src/lib.rs
@@ -17,8 +17,7 @@ pub fn from_unix_timestamp(timestamp: i64) -> time::OffsetDateTime {
 pub fn format(time: &time::OffsetDateTime) -> String {
     // This format string is correct, so unwrapping is fine.
     let format_description =
-        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] (UTC)")
-            .unwrap();
+        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second] (UTC)").unwrap();
 
     // We know this is correct.
     time.format(&format_description).unwrap()

--- a/trace-tools/trace-tools-attributes/src/lib.rs
+++ b/trace-tools/trace-tools-attributes/src/lib.rs
@@ -63,10 +63,7 @@ use syn::{
 /// .await;
 /// ```
 #[proc_macro_attribute]
-pub fn observe(
-    _args: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
+pub fn observe(_args: proc_macro::TokenStream, input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let observe_impl = parse_macro_input!(input as ObserveImpl);
     observe_impl.gen_tokens().into()
 }

--- a/trace-tools/trace-tools/examples/flamegraph.rs
+++ b/trace-tools/trace-tools/examples/flamegraph.rs
@@ -32,9 +32,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Creating flamegraph at {}.svg", graph_filename.display());
 
-    flamegrapher
-        .with_graph_file(graph_filename)?
-        .write_flamegraph()?;
+    flamegrapher.with_graph_file(graph_filename)?.write_flamegraph()?;
 
     Ok(())
 }

--- a/trace-tools/trace-tools/examples/logging.rs
+++ b/trace-tools/trace-tools/examples/logging.rs
@@ -18,15 +18,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .name(log_file.to_str().unwrap())
         .level_filter(log::LevelFilter::Warn);
 
-    let config = LoggerConfig::build()
-        .with_output(stdout)
-        .with_output(warn)
-        .finish();
+    let config = LoggerConfig::build().with_output(stdout).with_output(warn).finish();
 
-    let _ = trace_tools::subscriber::build()
-        .with_log_layer(config)
-        .init()
-        .unwrap();
+    let _ = trace_tools::subscriber::build().with_log_layer(config).init().unwrap();
 
     log();
     filtered::log();

--- a/trace-tools/trace-tools/src/error.rs
+++ b/trace-tools/trace-tools/src/error.rs
@@ -91,11 +91,7 @@ impl fmt::Display for FlamegrapherErrorKind {
             Self::Inferno(err) => write!(f, "{}", err),
             Self::Io(err) => write!(f, "{}", err),
             Self::MissingField(field) => write!(f, "flamegrapher builder missing field: {}", field),
-            Self::StackFileNotFound(path) => write!(
-                f,
-                "folded stack file {} does not exist",
-                path.to_string_lossy()
-            ),
+            Self::StackFileNotFound(path) => write!(f, "folded stack file {} does not exist", path.to_string_lossy()),
         }
     }
 }

--- a/trace-tools/trace-tools/src/subscriber/layer/flamegraph.rs
+++ b/trace-tools/trace-tools/src/subscriber/layer/flamegraph.rs
@@ -99,12 +99,7 @@ impl FlamegraphLayer {
     ///
     /// This string is then directly used in the folded stack file to describe the number of samples in
     /// the described stack.
-    fn stack_string<S>(
-        &self,
-        id: &span::Id,
-        ctx: &Context<'_, S>,
-        skip_current_span: bool,
-    ) -> String
+    fn stack_string<S>(&self, id: &span::Id, ctx: &Context<'_, S>, skip_current_span: bool) -> String
     where
         S: Subscriber + for<'a> LookupSpan<'a>,
     {
@@ -224,8 +219,6 @@ impl TryFrom<LocationVisitor> for SpanLocation {
     fn try_from(visitor: LocationVisitor) -> Result<Self, Self::Error> {
         let LocationVisitor { file, line } = visitor;
 
-        file.zip(line)
-            .map(|(file, line)| SpanLocation { file, line })
-            .ok_or(())
+        file.zip(line).map(|(file, line)| SpanLocation { file, line }).ok_or(())
     }
 }

--- a/trace-tools/trace-tools/src/subscriber/layer/log.rs
+++ b/trace-tools/trace-tools/src/subscriber/layer/log.rs
@@ -131,11 +131,7 @@ where
                 if make_writer.enabled(&metadata, &ctx) {
                     let mut writer = make_writer.make_writer();
 
-                    if self
-                        .fmt_events
-                        .format_event(&mut buf, &writer, event)
-                        .is_ok()
-                    {
+                    if self.fmt_events.format_event(&mut buf, &writer, event).is_ok() {
                         let _ = io::Write::write(&mut writer, buf.as_bytes());
                     }
 
@@ -175,26 +171,18 @@ impl LogLayer {
                 };
 
                 for exclusion in output_config.target_exclusions() {
-                    targets =
-                        targets.with_target(exclusion.clone().to_lowercase(), LevelFilter::OFF);
+                    targets = targets.with_target(exclusion.clone().to_lowercase(), LevelFilter::OFF);
                 }
 
                 let dest = match output_config.name() {
                     Self::STDOUT_NAME => LogDest::Stdout(output_config.color_enabled()),
                     name => {
-                        let file = OpenOptions::new()
-                            .write(true)
-                            .create(true)
-                            .append(true)
-                            .open(name)?;
+                        let file = OpenOptions::new().write(true).create(true).append(true).open(name)?;
                         LogDest::File(Mutex::new(file))
                     }
                 };
 
-                Ok(LogTargetMakeWriter::new(LogTarget {
-                    filter: targets,
-                    dest,
-                }))
+                Ok(LogTargetMakeWriter::new(LogTarget { filter: targets, dest }))
             })
             .collect::<Result<_, io::Error>>()
             .map_err(|err| Error::LogLayer(err.into()))?;
@@ -246,12 +234,7 @@ impl LogFormatter {
     ///
     /// Formatting can change depending on the output target of the writer, and so this must also be
     /// provided. An output that writes to `stdout` can potentially be formatted with text colors.
-    fn format_event<W>(
-        &self,
-        writer: &mut W,
-        output: &LogOutput,
-        event: &Event<'_>,
-    ) -> std::fmt::Result
+    fn format_event<W>(&self, writer: &mut W, output: &LogOutput, event: &Event<'_>) -> std::fmt::Result
     where
         W: std::fmt::Write,
     {

--- a/trace-tools/trace-tools/src/subscriber/layer/mod.rs
+++ b/trace-tools/trace-tools/src/subscriber/layer/mod.rs
@@ -30,9 +30,7 @@ use std::path::Path;
 ///
 /// # Panics
 /// This function will panic if the program is not built with `--cfg tokio_unstable`.
-pub fn flamegraph_layer<P: AsRef<Path>>(
-    stack_filename: P,
-) -> Result<(FlamegraphLayer, Flamegrapher), Error> {
+pub fn flamegraph_layer<P: AsRef<Path>>(stack_filename: P) -> Result<(FlamegraphLayer, Flamegrapher), Error> {
     #![allow(clippy::assertions_on_constants)]
     assert!(
         cfg!(tokio_unstable),
@@ -51,9 +49,7 @@ pub(crate) fn flamegraph_filter(meta: &Metadata<'_>) -> bool {
         return false;
     }
 
-    meta.name().starts_with("runtime")
-        || meta.target().starts_with("tokio")
-        || meta.target() == "trace_tools::observe"
+    meta.name().starts_with("runtime") || meta.target().starts_with("tokio") || meta.target() == "trace_tools::observe"
 }
 
 /// Creates a new [`LogLayer`], using the parameters provided by the given [`LoggerConfig`].
@@ -82,9 +78,7 @@ pub fn console_layer() -> Result<console_subscriber::ConsoleLayer, Error> {
         "task tracing requires building with RUSTFLAGS=\"--cfg tokio_unstable\"!"
     );
 
-    let (layer, server) = console_subscriber::ConsoleLayer::builder()
-        .with_default_env()
-        .build();
+    let (layer, server) = console_subscriber::ConsoleLayer::builder().with_default_env().build();
 
     std::thread::Builder::new()
         .name("console_subscriber".into())
@@ -95,12 +89,7 @@ pub fn console_layer() -> Result<console_subscriber::ConsoleLayer, Error> {
                 .build()
                 .expect("console subscriber runtime initialization failed");
 
-            runtime.block_on(async move {
-                server
-                    .serve()
-                    .await
-                    .expect("console subscriber server failed")
-            });
+            runtime.block_on(async move { server.serve().await.expect("console subscriber server failed") });
         })
         .expect("console subscriber could not spawn thread");
 

--- a/trace-tools/trace-tools/src/subscriber/mod.rs
+++ b/trace-tools/trace-tools/src/subscriber/mod.rs
@@ -55,10 +55,8 @@ pub type TraceSubscriber = BaseSubscriber;
 /// [`Layered`](tracing_subscriber::layer::Layered) type describing the composition of the subscriber constructed
 /// by the [`trace_tools`](crate) crate.
 #[cfg(feature = "tokio-console")]
-pub type TraceSubscriber = Layered<
-    Filtered<Option<console_subscriber::ConsoleLayer>, FilterFn, BaseSubscriber>,
-    BaseSubscriber,
->;
+pub type TraceSubscriber =
+    Layered<Filtered<Option<console_subscriber::ConsoleLayer>, FilterFn, BaseSubscriber>, BaseSubscriber>;
 
 /// Builder for the [`trace_tools`](crate) subscriber.
 ///
@@ -191,14 +189,11 @@ impl SubscriberBuilder {
             .map_or(Ok(None), |res| res.map(Some))
     }
 
-    fn build_flamegraph_layer(
-        &mut self,
-    ) -> Result<(Option<layer::FlamegraphLayer>, Option<Flamegrapher>), Error> {
+    fn build_flamegraph_layer(&mut self) -> Result<(Option<layer::FlamegraphLayer>, Option<Flamegrapher>), Error> {
         self.flamegraph_stack_file
             .take()
             .map_or(Ok((None, None)), |stack_file| {
-                layer::flamegraph_layer(stack_file)
-                    .map(|(layer, flamegrapher)| (Some(layer), Some(flamegrapher)))
+                layer::flamegraph_layer(stack_file).map(|(layer, flamegrapher)| (Some(layer), Some(flamegrapher)))
             })
     }
 }

--- a/trace-tools/trace-tools/src/util/flamegrapher.rs
+++ b/trace-tools/trace-tools/src/util/flamegrapher.rs
@@ -32,9 +32,9 @@ impl Flamegrapher {
         let stack_filename = stack_filename.as_ref().to_path_buf();
 
         if !stack_filename.exists() {
-            return Err(Error::Flamegrapher(
-                FlamegrapherErrorKind::StackFileNotFound(stack_filename),
-            ));
+            return Err(Error::Flamegrapher(FlamegrapherErrorKind::StackFileNotFound(
+                stack_filename,
+            )));
         }
 
         self.stack_filename = Some(stack_filename);
@@ -53,9 +53,9 @@ impl Flamegrapher {
 
         match graph_filename.parent() {
             Some(directory) if !directory.is_dir() => {
-                return Err(Error::Flamegrapher(
-                    FlamegrapherErrorKind::GraphFileInvalid(graph_filename),
-                ));
+                return Err(Error::Flamegrapher(FlamegrapherErrorKind::GraphFileInvalid(
+                    graph_filename,
+                )));
             }
             _ => {}
         }
@@ -73,24 +73,20 @@ impl Flamegrapher {
     ///  - An error was encountered when opening the folded stack file for reading.
     ///  - An error was encountered when creating the graph file.
     pub fn write_flamegraph(&self) -> Result<(), Error> {
-        let stack_filename = self.stack_filename.as_ref().ok_or_else(|| {
-            Error::Flamegrapher(FlamegrapherErrorKind::MissingField(
-                "stack_filename".to_string(),
-            ))
-        })?;
+        let stack_filename = self
+            .stack_filename
+            .as_ref()
+            .ok_or_else(|| Error::Flamegrapher(FlamegrapherErrorKind::MissingField("stack_filename".to_string())))?;
 
-        let graph_filename = self.graph_filename.as_ref().ok_or_else(|| {
-            Error::Flamegrapher(FlamegrapherErrorKind::MissingField(
-                "graph_filename".to_string(),
-            ))
-        })?;
+        let graph_filename = self
+            .graph_filename
+            .as_ref()
+            .ok_or_else(|| Error::Flamegrapher(FlamegrapherErrorKind::MissingField("graph_filename".to_string())))?;
 
-        let stack_file =
-            File::open(stack_filename).map_err(|err| Error::Flamegrapher(err.into()))?;
+        let stack_file = File::open(stack_filename).map_err(|err| Error::Flamegrapher(err.into()))?;
         let reader = BufReader::new(stack_file);
 
-        let graph_file =
-            File::create(graph_filename).map_err(|err| Error::Flamegrapher(err.into()))?;
+        let graph_file = File::create(graph_filename).map_err(|err| Error::Flamegrapher(err.into()))?;
         let writer = BufWriter::new(graph_file);
 
         let mut graph_options = inferno::flamegraph::Options::default();


### PR DESCRIPTION
This PR changes the `Packable` implementations of `Vec<T>`, `Box<[T]>`, `VecPrefix<T, B>` and `BoxedSlicePrefix<T, B>` in order to specialize them when `T` is equal to `u8`.

Before this changes. packable would do something like

```rust
for item in self.iter() {
     item.pack(packer)?;
}
```
to pack any byte buffer, meaning that each byte will trigger one write in the packer. With the changes proposed here. Byte buffers are packed and unpacked in a single read/write. Some benchmarks show a 6x performance improvement.

I ran the test suite of packable using miri given that this code relies on unsafe heavily, No issues were found.