### PR TITLE
Bump `trace_tools` version to 0.3.0

### DIFF
--- a/trace-tools/trace-tools/CHANGELOG.md
+++ b/trace-tools/trace-tools/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.3.0 - 2022-XX-XX
+## 0.3.0 - 2022-02-23
 
 ### Changed
 

--- a/trace-tools/trace-tools/Cargo.toml
+++ b/trace-tools/trace-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trace-tools"
-version = "0.2.0"
+version = "0.3.0"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Tracing and diagnostic tools for tasks"


### PR DESCRIPTION
Dependencies were changed when `fern_logger` was updated, but not the version number in `Cargo.toml`.