### PR TITLE
prefix-hex: Use `impl AsRef<str>` parameter instead of a generic `S: AsRef<str>` parameter

### DIFF
--- a/packable/packable-derive-test/tests/fail/invalid_packable_with.stderr
+++ b/packable/packable-derive-test/tests/fail/invalid_packable_with.stderr
@@ -13,4 +13,4 @@ note: required by a bound in `map_packable_err`
   --> $WORKSPACE/packable/packable/src/error.rs
    |
    |     fn map_packable_err<W>(self, f: impl Fn(U) -> W) -> Result<T, UnpackError<W, V>>;
-   |                                          ^^^^^^^^^^ required by this bound in `map_packable_err`
+   |                                          ^^^^^^^^^^ required by this bound in `UnpackErrorExt::map_packable_err`

--- a/packable/packable-derive-test/tests/lib.rs
+++ b/packable/packable-derive-test/tests/lib.rs
@@ -62,7 +62,6 @@ make_test!();
 #[rustversion::not(stable)]
 make_test!(
     incorrect_tag_enum,
-    invalid_packable_with,
     packable_is_structural,
     invalid_field_type_verify_with
 );

--- a/prefix-hex/CHANGELOG.md
+++ b/prefix-hex/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.7.0 - 2023-03-14
+
+### Fixed
+
+- Use `impl AsRef<str>` parameter instead of a generic `S: AsRef<str>` parameter;
+
 ## 0.6.0 - 2023-03-09
 
 ### Changed

--- a/prefix-hex/Cargo.toml
+++ b/prefix-hex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix-hex"
-version = "0.6.0"
+version = "0.7.0"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Encoding and decoding of hex strings with a 0x prefix."

--- a/prefix-hex/src/data.rs
+++ b/prefix-hex/src/data.rs
@@ -6,7 +6,7 @@ use alloc::{boxed::Box, format, string::String, vec::Vec};
 use crate::{strip_prefix, Error, FromHexPrefixed, ToHexPrefixed};
 
 impl FromHexPrefixed for Vec<u8> {
-    fn from_hex_prefixed<S: AsRef<str>>(hex: S) -> Result<Self, Error> {
+    fn from_hex_prefixed(hex: impl AsRef<str>) -> Result<Self, Error> {
         let hex = strip_prefix(hex.as_ref())?;
         hex::decode(hex).map_err(Into::into)
     }
@@ -22,7 +22,7 @@ impl<const N: usize> FromHexPrefixed for [u8; N]
 where
     Self: hex::FromHex,
 {
-    fn from_hex_prefixed<S: AsRef<str>>(hex: S) -> Result<Self, Error> {
+    fn from_hex_prefixed(hex: impl AsRef<str>) -> Result<Self, Error> {
         let hex = strip_prefix(hex.as_ref())?;
         let mut buffer = [0; N];
         hex::decode_to_slice(hex, &mut buffer).map_err(|e| match e {

--- a/prefix-hex/src/lib.rs
+++ b/prefix-hex/src/lib.rs
@@ -25,7 +25,7 @@ pub use error::Error;
 /// Tries to decode an hexadecimal encoded string with a `0x` prefix.
 pub trait FromHexPrefixed: Sized {
     /// Tries to decode an hexadecimal encoded string with a `0x` prefix.
-    fn from_hex_prefixed<S: AsRef<str>>(hex: S) -> Result<Self, Error>;
+    fn from_hex_prefixed(hex: impl AsRef<str>) -> Result<Self, Error>;
 }
 
 /// Encodes data into an hexadecimal encoded string with a `0x` prefix.
@@ -46,7 +46,7 @@ pub trait ToHexPrefixed {
 /// let result = prefix_hex::decode("0x000102");
 /// assert_eq!(result, Ok([0x0, 0x1, 0x2]));
 /// ```
-pub fn decode<T: FromHexPrefixed, S: AsRef<str>>(hex: S) -> Result<T, Error> {
+pub fn decode<T: FromHexPrefixed>(hex: impl AsRef<str>) -> Result<T, Error> {
     T::from_hex_prefixed(hex)
 }
 

--- a/prefix-hex/src/primitive_types.rs
+++ b/prefix-hex/src/primitive_types.rs
@@ -8,7 +8,7 @@ use crate::{strip_prefix, Error, FromHexPrefixed, ToHexPrefixed};
 macro_rules! impl_from_to_hex {
     ($type:ty) => {
         impl FromHexPrefixed for $type {
-            fn from_hex_prefixed<S: AsRef<str>>(hex: S) -> Result<Self, Error> {
+            fn from_hex_prefixed(hex: impl AsRef<str>) -> Result<Self, Error> {
                 let hex = strip_prefix(hex.as_ref())?;
 
                 if hex.is_empty() {

--- a/prefix-hex/tests/data.rs
+++ b/prefix-hex/tests/data.rs
@@ -11,7 +11,7 @@ fn array_decode() {
 #[test]
 fn array_decode_invalid_hex() {
     assert_eq!(
-        prefix_hex::decode::<[u8; 3], _>("0x00000y"),
+        prefix_hex::decode::<[u8; 3]>("0x00000y"),
         Err(Error::InvalidHexCharacter { c: 'y', index: 5 })
     );
 }
@@ -19,7 +19,7 @@ fn array_decode_invalid_hex() {
 #[test]
 fn array_decode_invalid_length_too_short() {
     assert_eq!(
-        prefix_hex::decode::<[u8; 3], _>("0x52fd6"),
+        prefix_hex::decode::<[u8; 3]>("0x52fd6"),
         Err(Error::InvalidStringLengthSlice { expected: 6, actual: 5 })
     );
 }
@@ -27,7 +27,7 @@ fn array_decode_invalid_length_too_short() {
 #[test]
 fn array_decode_invalid_length_too_long() {
     assert_eq!(
-        prefix_hex::decode::<[u8; 3], _>("0x52fd643"),
+        prefix_hex::decode::<[u8; 3]>("0x52fd643"),
         Err(Error::InvalidStringLengthSlice { expected: 6, actual: 7 })
     );
 }
@@ -35,7 +35,7 @@ fn array_decode_invalid_length_too_long() {
 #[test]
 fn array_decode_no_prefix() {
     assert_eq!(
-        prefix_hex::decode::<[u8; 3], _>("004200"),
+        prefix_hex::decode::<[u8; 3]>("004200"),
         Err(Error::InvalidPrefix { c0: '0', c1: '0' })
     );
 }
@@ -43,7 +43,7 @@ fn array_decode_no_prefix() {
 #[test]
 fn array_decode_wrong_prefix() {
     assert_eq!(
-        prefix_hex::decode::<[u8; 3], _>("0yffffff"),
+        prefix_hex::decode::<[u8; 3]>("0yffffff"),
         Err(Error::InvalidPrefix { c0: '0', c1: 'y' })
     );
 }
@@ -82,7 +82,7 @@ fn boxed_slice_reference_encode() {
 
 #[test]
 fn vec_decode() {
-    assert_eq!(prefix_hex::decode::<Vec<u8>, _>("0x000102").unwrap(), [0x0, 0x1, 0x2]);
+    assert_eq!(prefix_hex::decode::<Vec<u8>>("0x000102").unwrap(), [0x0, 0x1, 0x2]);
 }
 
 #[test]
@@ -92,7 +92,7 @@ fn vec_decode_empty_string() {
 
 #[test]
 fn vec_decode_odd_length() {
-    assert_eq!(prefix_hex::decode::<Vec<u8>, _>("0xf0f0f"), Err(Error::OddLength));
+    assert_eq!(prefix_hex::decode::<Vec<u8>>("0xf0f0f"), Err(Error::OddLength));
 }
 
 #[test]

--- a/prefix-hex/tests/primitive_types.rs
+++ b/prefix-hex/tests/primitive_types.rs
@@ -17,7 +17,7 @@ macro_rules! test_impl {
             #[test]
             fn [< $name _decode_err_no_body >]() {
                 assert_eq!(
-                    prefix_hex::decode::<$type, _>("0x"),
+                    prefix_hex::decode::<$type>("0x"),
                     Err(prefix_hex::Error::InvalidStringLength)
                 );
             }
@@ -25,7 +25,7 @@ macro_rules! test_impl {
             #[test]
             fn [< $name _decode_invalid_character >]() {
                 assert_eq!(
-                    prefix_hex::decode::<$type, _>("0x271y"),
+                    prefix_hex::decode::<$type>("0x271y"),
                     Err(prefix_hex::Error::InvalidHexCharacter{index: 3, c: 'y'})
                 );
             }


### PR DESCRIPTION
Fixes #64 