### PR TITLE
Fix packable `no_std`

### DIFF
--- a/packable/packable-derive-test/Cargo.toml
+++ b/packable/packable-derive-test/Cargo.toml
@@ -16,7 +16,7 @@ name = "tests"
 path = "tests/lib.rs"
 
 [dev-dependencies]
-packable = { version = "=0.8.0", path = "../packable", default-features = false }
+packable = { version = "=0.8.1", path = "../packable", default-features = false }
 
 rustversion = { version = "1.0.9", default-features = false }
 trybuild = { version = "1.0.71", default-features = false, features = [ "diff" ] }

--- a/packable/packable-derive-test/tests/fail/incorrect_tag_enum.stderr
+++ b/packable/packable-derive-test/tests/fail/incorrect_tag_enum.stderr
@@ -10,19 +10,19 @@ help: change the type of the numeric literal from `u32` to `u8`
    |                       ~~
 
 error[E0308]: mismatched types
-   --> tests/fail/incorrect_tag_enum.rs:10:10
-    |
-10  | #[derive(Packable)]
-    |          ^^^^^^^^
-    |          |
-    |          expected `u8`, found `u32`
-    |          arguments to this function are incorrect
-    |
-    = note: expected reference `&u8`
-               found reference `&u32`
-note: associated function defined here
-   --> $WORKSPACE/packable/packable/src/packable/mod.rs
-    |
-    |     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
-    |        ^^^^
-    = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/fail/incorrect_tag_enum.rs:10:10
+   |
+10 | #[derive(Packable)]
+   |          ^^^^^^^^
+   |          |
+   |          expected `&u8`, found `&u32`
+   |          arguments to this function are incorrect
+   |
+   = note: expected reference `&u8`
+              found reference `&u32`
+note: method defined here
+  --> $WORKSPACE/packable/packable/src/packable/mod.rs
+   |
+   |     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
+   |        ^^^^
+   = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packable/packable-derive-test/tests/fail/invalid_field_type_verify_with.stderr
+++ b/packable/packable-derive-test/tests/fail/invalid_field_type_verify_with.stderr
@@ -4,7 +4,7 @@ error[E0308]: mismatched types
 33 | #[derive(Packable)]
    |          ^^^^^^^^
    |          |
-   |          expected `u64`, found `u8`
+   |          expected `&u64`, found `&u8`
    |          arguments to this function are incorrect
    |
    = note: expected reference `&u64`

--- a/packable/packable-derive-test/tests/lib.rs
+++ b/packable/packable-derive-test/tests/lib.rs
@@ -60,8 +60,4 @@ macro_rules! make_test {
 #[rustversion::stable]
 make_test!();
 #[rustversion::not(stable)]
-make_test!(
-    incorrect_tag_enum,
-    packable_is_structural,
-    invalid_field_type_verify_with
-);
+make_test!(packable_is_structural);

--- a/packable/packable/Cargo.toml
+++ b/packable/packable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packable"
-version = "0.8.0"
+version = "0.8.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "A crate for packing and unpacking binary representations."

--- a/packable/packable/Cargo.toml
+++ b/packable/packable/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://www.iota.org"
 
 [features]
 io = [ "std" ]
-std = [ ]
+std = [ "serde?/std", "primitive-types?/std" ]
 usize = [ ]
 
 [build-dependencies]
@@ -22,4 +22,4 @@ autocfg = { version = "1.1.0", default-features = false }
 packable-derive = { version = "=0.7.0", path = "../packable-derive", default-features = false }
 
 primitive-types = { version = "0.12.0", default-features = false, optional = true }
-serde = { version = "1.0.145", default-features = false, features = [ "derive", "std" ], optional = true }
+serde = { version = "1.0.145", default-features = false, features = [ "derive" ], optional = true }


### PR DESCRIPTION
The serde dependency in packable erroneously uses the `std` feature.