### PR TITLE
Add missing To/From Hex Prefixed impls

### DIFF
--- a/auth-helper/src/password.rs
+++ b/auth-helper/src/password.rs
@@ -11,7 +11,7 @@ pub type Error = argon2::Error;
 
 /// Generates a salt to be used for password hashing.
 pub fn generate_salt() -> [u8; 32] {
-    rand::rngs::OsRng::default().gen()
+    rand::rngs::OsRng.gen()
 }
 
 /// Hashes a password together with a salt.

--- a/prefix-hex/CHANGELOG.md
+++ b/prefix-hex/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `FromHexPrefixed` impl for boxed slice;
+- `ToHexPrefixed` impl for Vec references;
 
 ## 0.7.0 - 2023-03-14
 

--- a/prefix-hex/CHANGELOG.md
+++ b/prefix-hex/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.7.1 - 2023-07-19
+
+### Added
+
+- `FromHexPrefixed` impl for boxed slice;
+
 ## 0.7.0 - 2023-03-14
 
 ### Fixed

--- a/prefix-hex/Cargo.toml
+++ b/prefix-hex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prefix-hex"
-version = "0.7.0"
+version = "0.7.1"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "Encoding and decoding of hex strings with a 0x prefix."

--- a/prefix-hex/src/data.rs
+++ b/prefix-hex/src/data.rs
@@ -19,12 +19,6 @@ impl FromHexPrefixed for Box<[u8]> {
     }
 }
 
-impl ToHexPrefixed for Vec<u8> {
-    fn to_hex_prefixed(self) -> String {
-        format!("0x{}", hex::encode(self))
-    }
-}
-
 impl<const N: usize> FromHexPrefixed for [u8; N]
 where
     Self: hex::FromHex,
@@ -61,7 +55,7 @@ where
     }
 }
 
-macro_rules! impl_for_as_ref_type {
+macro_rules! impl_to_hex {
     ($type:ty) => {
         impl ToHexPrefixed for $type {
             fn to_hex_prefixed(self) -> String {
@@ -71,6 +65,8 @@ macro_rules! impl_for_as_ref_type {
     };
 }
 
-impl_for_as_ref_type!(Box<[u8]>);
-impl_for_as_ref_type!(&Box<[u8]>);
-impl_for_as_ref_type!(&[u8]);
+impl_to_hex!(Box<[u8]>);
+impl_to_hex!(&Box<[u8]>);
+impl_to_hex!(&[u8]);
+impl_to_hex!(Vec<u8>);
+impl_to_hex!(&Vec<u8>);

--- a/prefix-hex/src/data.rs
+++ b/prefix-hex/src/data.rs
@@ -12,6 +12,13 @@ impl FromHexPrefixed for Vec<u8> {
     }
 }
 
+impl FromHexPrefixed for Box<[u8]> {
+    fn from_hex_prefixed(hex: impl AsRef<str>) -> Result<Self, Error> {
+        let hex = strip_prefix(hex.as_ref())?;
+        hex::decode(hex).map(Vec::into_boxed_slice).map_err(Into::into)
+    }
+}
+
 impl ToHexPrefixed for Vec<u8> {
     fn to_hex_prefixed(self) -> String {
         format!("0x{}", hex::encode(self))

--- a/prefix-hex/tests/primitive_types.rs
+++ b/prefix-hex/tests/primitive_types.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 IOTA Stiftung
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(all(feature = "primitive-types"))]
+#![cfg(feature = "primitive-types")]
 
 macro_rules! test_impl {
     ($name:ident, $type:ty) => {


### PR DESCRIPTION
## Description

This PR adds a missing impl of `FromHexPrefixed` for boxed slices and `ToHexPrefixed` for `&Vec<u8>`.