### PR TITLE
Make BTreeSet impls fail on unordered

### DIFF
--- a/packable/packable-derive-test/Cargo.toml
+++ b/packable/packable-derive-test/Cargo.toml
@@ -16,7 +16,7 @@ name = "tests"
 path = "tests/lib.rs"
 
 [dev-dependencies]
-packable = { version = "=0.8.2", path = "../packable", default-features = false }
+packable = { version = "=0.8.3", path = "../packable", default-features = false }
 
 rustversion = { version = "1.0.9", default-features = false }
 trybuild = { version = "1.0.71", default-features = false, features = [ "diff" ] }

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.8.3 - 2023-09-15
+
+### Added
+
+- `UnpackOrderedSetError`;
+
+### Fixed
+
+- `BTreeSet` impls and `BTreeSetPrefix` unpack now fails if the data is unordered;
+
 ## 0.8.2 - 2023-09-07
 
 ### Added

--- a/packable/packable/Cargo.toml
+++ b/packable/packable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packable"
-version = "0.8.2"
+version = "0.8.3"
 authors = [ "IOTA Stiftung" ]
 edition = "2021"
 description = "A crate for packing and unpacking binary representations."

--- a/packable/packable/src/packable/prefix/btreeset.rs
+++ b/packable/packable/src/packable/prefix/btreeset.rs
@@ -131,15 +131,15 @@ where
             let item = T::unpack::<_, VERIFY>(unpacker, visitor)
                 .map_packable_err(UnpackSetError::Item)
                 .map_packable_err(Self::UnpackError::from)?;
-            if let Some(last) = set.last() {
-                if last > &item {
-                    return Err(UnpackError::Packable(Self::UnpackError::Unordered));
-                }
-            }
             if set.contains(&item) {
                 return Err(UnpackError::Packable(Self::UnpackError::Set(
                     UnpackSetError::DuplicateItem(item),
                 )));
+            }
+            if let Some(last) = set.last() {
+                if last > &item {
+                    return Err(UnpackError::Packable(Self::UnpackError::Unordered));
+                }
             }
             set.insert(item);
         }

--- a/packable/packable/src/packable/set.rs
+++ b/packable/packable/src/packable/set.rs
@@ -52,6 +52,52 @@ impl<T, I: fmt::Display, P: fmt::Display> fmt::Display for UnpackSetError<T, I, 
     }
 }
 
+/// Error type raised when a semantic error occurs while unpacking an ordered set.
+pub enum UnpackOrderedSetError<T, I, P> {
+    /// A set error.
+    Set(UnpackSetError<T, I, P>),
+    /// An unordered set.
+    Unordered,
+}
+
+impl<T, I, P> From<UnpackSetError<T, I, P>> for UnpackOrderedSetError<T, I, P> {
+    fn from(value: UnpackSetError<T, I, P>) -> Self {
+        Self::Set(value)
+    }
+}
+
+impl<T, I: fmt::Debug, P: fmt::Debug> fmt::Debug for UnpackOrderedSetError<T, I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Set(arg0) => f.debug_tuple("Set").field(arg0).finish(),
+            Self::Unordered => f.debug_tuple("Unordered").finish(),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T, I, P> std::error::Error for UnpackOrderedSetError<T, I, P>
+where
+    I: std::error::Error,
+    P: std::error::Error,
+{
+}
+
+impl<T, I, P> From<Infallible> for UnpackOrderedSetError<T, I, P> {
+    fn from(err: Infallible) -> Self {
+        match err {}
+    }
+}
+
+impl<T, I: fmt::Display, P: fmt::Display> fmt::Display for UnpackOrderedSetError<T, I, P> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Set(s) => s.fmt(f),
+            Self::Unordered => write!(f, "unordered set"),
+        }
+    }
+}
+
 #[cfg(feature = "usize")]
 mod btreeset {
     use alloc::collections::BTreeSet;
@@ -60,7 +106,7 @@ mod btreeset {
     use crate::{error::UnpackError, packer::Packer, unpacker::Unpacker, Packable};
 
     impl<T: Packable + Ord> Packable for BTreeSet<T> {
-        type UnpackError = UnpackSetError<T, T::UnpackError, <usize as Packable>::UnpackError>;
+        type UnpackError = UnpackOrderedSetError<T, T::UnpackError, <usize as Packable>::UnpackError>;
         type UnpackVisitor = T::UnpackVisitor;
 
         #[inline]
@@ -85,14 +131,23 @@ mod btreeset {
             let len = u64::unpack::<_, VERIFY>(unpacker, &())
                 .coerce()?
                 .try_into()
-                .map_err(|err| UnpackError::Packable(Self::UnpackError::Prefix(err)))?;
+                .map_err(|err| UnpackError::Packable(UnpackSetError::Prefix(err).into()))?;
 
             let mut set = BTreeSet::new();
 
             for _ in 0..len {
-                let item = T::unpack::<_, VERIFY>(unpacker, visitor).map_packable_err(Self::UnpackError::Item)?;
+                let item = T::unpack::<_, VERIFY>(unpacker, visitor)
+                    .map_packable_err(UnpackSetError::Item)
+                    .map_packable_err(Self::UnpackError::from)?;
+                if let Some(last) = set.last() {
+                    if last > &item {
+                        return Err(UnpackError::Packable(Self::UnpackError::Unordered));
+                    }
+                }
                 if set.contains(&item) {
-                    return Err(UnpackError::Packable(Self::UnpackError::DuplicateItem(item)));
+                    return Err(UnpackError::Packable(Self::UnpackError::Set(
+                        UnpackSetError::DuplicateItem(item),
+                    )));
                 }
                 set.insert(item);
             }

--- a/packable/packable/src/packable/set.rs
+++ b/packable/packable/src/packable/set.rs
@@ -139,15 +139,15 @@ mod btreeset {
                 let item = T::unpack::<_, VERIFY>(unpacker, visitor)
                     .map_packable_err(UnpackSetError::Item)
                     .map_packable_err(Self::UnpackError::from)?;
-                if let Some(last) = set.last() {
-                    if last > &item {
-                        return Err(UnpackError::Packable(Self::UnpackError::Unordered));
-                    }
-                }
                 if set.contains(&item) {
                     return Err(UnpackError::Packable(Self::UnpackError::Set(
                         UnpackSetError::DuplicateItem(item),
                     )));
+                }
+                if let Some(last) = set.last() {
+                    if last > &item {
+                        return Err(UnpackError::Packable(Self::UnpackError::Unordered));
+                    }
                 }
                 set.insert(item);
             }

--- a/packable/packable/tests/boxed_slice_prefix.rs
+++ b/packable/packable/tests/boxed_slice_prefix.rs
@@ -30,7 +30,7 @@ fn boxed_slice_prefix_from_boxed_slice_truncated_error() {
 }
 
 macro_rules! impl_packable_test_for_boxed_slice_prefix {
-    ($packable_boxed_slice_prefix:ident, $packable_boxed_slice_prefix_invalid_length:ident, $ty:ty) => {
+    ($packable_boxed_slice_prefix:ident, $ty:ty) => {
         #[test]
         fn $packable_boxed_slice_prefix() {
             assert_eq!(
@@ -85,26 +85,10 @@ macro_rules! impl_packable_test_for_bounded_boxed_slice_prefix {
     };
 }
 
-impl_packable_test_for_boxed_slice_prefix!(
-    packable_boxed_slice_prefix_u8,
-    packable_boxed_slice_prefix_invalid_length_u8,
-    u8
-);
-impl_packable_test_for_boxed_slice_prefix!(
-    packable_boxed_slice_prefix_u16,
-    packable_boxed_slice_prefix_invalid_length_u16,
-    u16
-);
-impl_packable_test_for_boxed_slice_prefix!(
-    packable_boxed_slice_prefix_u32,
-    packable_boxed_slice_prefix_invalid_length_u32,
-    u32
-);
-impl_packable_test_for_boxed_slice_prefix!(
-    packable_boxed_slice_prefix_u64,
-    packable_boxed_slice_prefix_invalid_length_u64,
-    u64
-);
+impl_packable_test_for_boxed_slice_prefix!(packable_boxed_slice_prefix_u8, u8);
+impl_packable_test_for_boxed_slice_prefix!(packable_boxed_slice_prefix_u16, u16);
+impl_packable_test_for_boxed_slice_prefix!(packable_boxed_slice_prefix_u32, u32);
+impl_packable_test_for_boxed_slice_prefix!(packable_boxed_slice_prefix_u64, u64);
 
 impl_packable_test_for_bounded_boxed_slice_prefix!(
     packable_boxed_slice_prefix_bounded_u8,

--- a/packable/packable/tests/btreeset.rs
+++ b/packable/packable/tests/btreeset.rs
@@ -8,7 +8,7 @@ mod common;
 #[test]
 fn packable_btreeset() {
     assert_eq!(
-        common::generic_test(&BTreeSet::from([Some(0u32), None])).0.len(),
+        common::generic_test(&BTreeSet::from([None, Some(0u32)])).0.len(),
         core::mem::size_of::<u64>()
             + (core::mem::size_of::<u8>() + core::mem::size_of::<u32>())
             + core::mem::size_of::<u8>()

--- a/packable/packable/tests/btreeset.rs
+++ b/packable/packable/tests/btreeset.rs
@@ -23,7 +23,7 @@ fn packable_btreeset() {
 
 #[test]
 fn invalid_duplicate() {
-    let bytes = [1, 2, 3, 4, 3];
+    let bytes = [1, 2, 3, 3, 4];
     let bytes = Vec::from_iter(bytes.len().to_le_bytes().into_iter().chain(bytes));
 
     let prefixed = BTreeSet::<u8>::unpack_verified(bytes, &());

--- a/packable/packable/tests/btreeset_prefix.rs
+++ b/packable/packable/tests/btreeset_prefix.rs
@@ -58,7 +58,7 @@ macro_rules! impl_packable_test_for_btreeset_prefix {
             const LEN_AS_TY: $ty = LEN as $ty;
 
             let mut bytes = (0u8..LEN as u8).collect::<Vec<_>>();
-            bytes[LEN - 1] = bytes[LEN - 3];
+            bytes[LEN - 1] = bytes[LEN - 2];
             let dup = bytes[LEN - 1];
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
@@ -142,7 +142,7 @@ macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
             const LEN_AS_TY: $ty = LEN as $ty;
 
             let mut bytes = (0u8..LEN as u8).collect::<Vec<_>>();
-            bytes[LEN - 1] = bytes[LEN - 3];
+            bytes[LEN - 1] = bytes[LEN - 2];
             let dup = bytes[LEN - 1];
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));

--- a/packable/packable/tests/btreeset_prefix.rs
+++ b/packable/packable/tests/btreeset_prefix.rs
@@ -34,8 +34,8 @@ fn btreeset_prefix_from_btreeset_truncated_error() {
 
 macro_rules! impl_packable_test_for_btreeset_prefix {
     (
-        $packable_btreeset_prefix:ident, 
-        $packable_btreeset_prefix_duplicate:ident, 
+        $packable_btreeset_prefix:ident,
+        $packable_btreeset_prefix_duplicate:ident,
         $packable_btreeset_prefix_unordered:ident,
         $ty:ty) => {
         #[test]
@@ -57,15 +57,19 @@ macro_rules! impl_packable_test_for_btreeset_prefix {
             const LEN: usize = 64;
             const LEN_AS_TY: $ty = LEN as $ty;
 
-            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(core::iter::repeat(0).take(LEN + 1)));
+            let mut bytes = (0u8..LEN as u8).collect::<Vec<_>>();
+            bytes[LEN - 1] = bytes[LEN - 3];
+            let dup = bytes[LEN - 1];
+
+            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
             let prefixed = BTreeSetPrefix::<u8, $ty>::unpack_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
                 Err(UnpackError::Packable(UnpackOrderedSetError::Set(
-                    UnpackSetError::DuplicateItem(0u8)
-                ))),
+                    UnpackSetError::DuplicateItem(d)
+                ))) if d == dup
             ));
         }
 
@@ -74,7 +78,10 @@ macro_rules! impl_packable_test_for_btreeset_prefix {
             const LEN: usize = 64;
             const LEN_AS_TY: $ty = LEN as $ty;
 
-            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain((0..LEN as u8).rev()));
+            let mut bytes = (0u8..LEN as u8).collect::<Vec<_>>();
+            bytes.swap(0, 1);
+
+            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
             let prefixed = BTreeSetPrefix::<u8, $ty>::unpack_verified(bytes, &());
 
@@ -88,14 +95,14 @@ macro_rules! impl_packable_test_for_btreeset_prefix {
 
 macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
     (
-        $packable_btreeset_prefix:ident, 
-        $packable_btreeset_prefix_invalid_length:ident, 
-        $packable_btreeset_prefix_duplicate:ident, 
+        $packable_btreeset_prefix:ident,
+        $packable_btreeset_prefix_invalid_length:ident,
+        $packable_btreeset_prefix_duplicate:ident,
         $packable_btreeset_prefix_unordered:ident,
-        $ty:ty, 
-        $bounded:ident, 
-        $err:ident, 
-        $min:expr, 
+        $ty:ty,
+        $bounded:ident,
+        $err:ident,
+        $min:expr,
         $max:expr) => {
         #[test]
         fn $packable_btreeset_prefix() {
@@ -121,7 +128,6 @@ macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
 
             let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
 
-
             assert!(matches!(
                 prefixed,
                 Err(UnpackError::Packable(UnpackOrderedSetError::Set(
@@ -135,15 +141,19 @@ macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
             const LEN: usize = $max;
             const LEN_AS_TY: $ty = LEN as $ty;
 
-            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(core::iter::repeat(0).take(LEN)));
+            let mut bytes = (0u8..LEN as u8).collect::<Vec<_>>();
+            bytes[LEN - 1] = bytes[LEN - 3];
+            let dup = bytes[LEN - 1];
+
+            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
             let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
                 Err(UnpackError::Packable(UnpackOrderedSetError::Set(
-                    UnpackSetError::DuplicateItem(0u8)
-                ))),
+                    UnpackSetError::DuplicateItem(d)
+                ))) if d == dup
             ));
         }
 
@@ -152,7 +162,10 @@ macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
             const LEN: usize = $max;
             const LEN_AS_TY: $ty = LEN as $ty;
 
-            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain((0..LEN as u8).rev()));
+            let mut bytes = (0u8..LEN as u8).collect::<Vec<_>>();
+            bytes.swap(0, 1);
+
+            let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
             let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
 


### PR DESCRIPTION
## Description

The BTreeSet impls now fail to unpack if the data was not properly ordered. I added a new error type to support this, which wraps the set error.