### PR TITLE
Update syn version for packable

### DIFF
--- a/packable/packable-derive/Cargo.toml
+++ b/packable/packable-derive/Cargo.toml
@@ -15,12 +15,10 @@ proc-macro = true
 
 [dependencies]
 proc-macro-crate = { version = "1.3.1", default-features = false }
-proc-macro-error = { version = "1.0.4", default-features = false, features = [
-    "syn-error",
-] }
+
 proc-macro2 = { version = "1.0.69", default-features = false }
 quote = { version = "1.0.33", default-features = false }
-syn = { version = "1.0.109", default-features = false, features = [
+syn = { version = "2.0.39", default-features = false, features = [
     "full",
     "extra-traits",
     "parsing",

--- a/packable/packable-derive/src/enum_info.rs
+++ b/packable/packable-derive/src/enum_info.rs
@@ -19,7 +19,7 @@ impl EnumInfo {
     pub(crate) fn new(ident: Ident, data: DataEnum, attrs: &[Attribute], crate_name: &Ident) -> Result<Self> {
         let repr_type = attrs
             .iter()
-            .find(|attr| attr.path.is_ident("repr"))
+            .find(|attr| attr.path().is_ident("repr"))
             .map(Attribute::parse_args::<Type>)
             .transpose()?;
 

--- a/packable/packable-derive/src/lib.rs
+++ b/packable/packable-derive/src/lib.rs
@@ -18,15 +18,13 @@ mod variant_info;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_crate::{crate_name, FoundCrate};
-use proc_macro_error::{abort, proc_macro_error};
 use quote::ToTokens;
 use syn::{parse_macro_input, Ident};
 
 use self::trait_impl::TraitImpl;
 
-#[proc_macro_error]
 #[proc_macro_derive(Packable, attributes(packable))]
-pub fn packable(input: TokenStream) -> TokenStream {
+pub fn packable(input: proc_macro::TokenStream) -> TokenStream {
     let input = parse_macro_input!(input);
 
     let crate_string = match crate_name("packable").expect("packable should be present in `Cargo.toml`") {
@@ -35,7 +33,8 @@ pub fn packable(input: TokenStream) -> TokenStream {
     };
 
     match TraitImpl::new(input, Ident::new(&crate_string, Span::call_site())) {
-        Ok(trait_impl) => trait_impl.into_token_stream().into(),
-        Err(err) => abort!(err),
+        Ok(trait_impl) => trait_impl.into_token_stream(),
+        Err(err) => err.to_compile_error(),
     }
+    .into()
 }

--- a/packable/packable-derive/src/parse.rs
+++ b/packable/packable-derive/src/parse.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 
 pub(crate) fn filter_attrs(attrs: &[Attribute]) -> impl Iterator<Item = &Attribute> + Clone {
-    attrs.iter().filter(|attr| attr.path.is_ident("packable"))
+    attrs.iter().filter(|attr| attr.path().is_ident("packable"))
 }
 
 pub(crate) fn skip_stream(stream: ParseStream) -> Result<()> {


### PR DESCRIPTION
Hi,  this should solve iotaledger/iota-sdk#1200 . 

Also removed the proc-macro-error as it is using the old version of syn and it's not maintained so instead of `abort!` it currently works with `to_compile_error`.