### PR TITLE
Remove the default bound from Packable::Visitor

### DIFF
--- a/packable/packable-derive-test/Cargo.toml
+++ b/packable/packable-derive-test/Cargo.toml
@@ -16,7 +16,7 @@ name = "tests"
 path = "tests/lib.rs"
 
 [dev-dependencies]
-packable = { version = "=0.10.1", path = "../packable", default-features = false }
+packable = { version = "=0.11.0", path = "../packable", default-features = false }
 
 rustversion = { version = "1.0.14", default-features = false }
 trybuild = { version = "1.0.88", default-features = false, features = ["diff"] }

--- a/packable/packable-derive-test/tests/fail/incorrect_tag_enum.stderr
+++ b/packable/packable-derive-test/tests/fail/incorrect_tag_enum.stderr
@@ -26,9 +26,3 @@ note: method defined here
    |     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
    |        ^^^^
    = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: could not evaluate constant pattern
-  --> tests/fail/incorrect_tag_enum.rs:14:22
-   |
-14 |     #[packable(tag = 0u32)]
-   |                      ^^^^

--- a/packable/packable-derive-test/tests/fail/incorrect_tag_enum.stderr
+++ b/packable/packable-derive-test/tests/fail/incorrect_tag_enum.stderr
@@ -26,3 +26,9 @@ note: method defined here
    |     fn pack<P: Packer>(&self, packer: &mut P) -> Result<(), P::Error>;
    |        ^^^^
    = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: could not evaluate constant pattern
+  --> tests/fail/incorrect_tag_enum.rs:14:22
+   |
+14 |     #[packable(tag = 0u32)]
+   |                      ^^^^

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.rs
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value(value: &u64, visitor: Option<&()>) -> Result<(), PickyError> {
-    if visitor.is_none() || value == 42 {
+fn verify_value(value: &u64) -> Result<(), PickyError> {
+    if value == 42 {
         Ok(())
     } else {
         Err(PickyError(value as u8))

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.rs
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.rs
@@ -21,7 +21,7 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value(value: &u64) -> Result<(), PickyError> {
+fn verify_value(&value: &u64) -> Result<(), PickyError> {
     if value == 42 {
         Ok(())
     } else {

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.rs
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value<const VERIFY: bool>(&value: &u64) -> Result<(), PickyError> {
-    if !VERIFY || value == 42 {
+fn verify_value(value: &u64, visitor: Option<&()>) -> Result<(), PickyError> {
+    if visitor.is_none() || value == 42 {
         Ok(())
     } else {
         Err(PickyError(value as u8))

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.stderr
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.stderr
@@ -12,6 +12,6 @@ error[E0308]: mismatched types
 note: function defined here
   --> tests/fail/invalid_verify_with_field_type.rs:24:4
    |
-24 | fn verify_value<const VERIFY: bool>(&value: &u64) -> Result<(), PickyError> {
-   |    ^^^^^^^^^^^^                     ------------
+24 | fn verify_value(&value: &u64) -> Result<(), PickyError> {
+   |    ^^^^^^^^^^^^ ------------
    = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.stderr
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_field_type.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> tests/fail/invalid_verify_with_field_type.rs:32:10
    |
 32 | #[derive(Packable)]
-   |          ^^^^^^^^
-   |          |
-   |          expected `&u64`, found `&u8`
-   |          arguments to this function are incorrect
+   |          ^^^^^^^^ expected `&u64`, found `&u8`
+33 | #[packable(unpack_error = PickyError)]
+34 | pub struct Picky(#[packable(verify_with = verify_value)] u8);
+   |                                           ------------ arguments to this function are incorrect
    |
    = note: expected reference `&u64`
               found reference `&u8`

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.rs
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify<const VERIFY: bool>(&value: &u64) -> Result<(), PickyError> {
-    if !VERIFY || value == 42 {
+fn verify(value: &u64, visitor: Option<&()>) -> Result<(), PickyError> {
+    if visitor.is_none() || value == 42 {
         Ok(())
     } else {
         Err(PickyError(value as u8))

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.rs
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.rs
@@ -21,7 +21,7 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(value: &u64) -> Result<(), PickyError> {
+fn verify(&value: &u64) -> Result<(), PickyError> {
     if value == 42 {
         Ok(())
     } else {

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.rs
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(value: &u64, visitor: Option<&()>) -> Result<(), PickyError> {
-    if visitor.is_none() || value == 42 {
+fn verify(value: &u64) -> Result<(), PickyError> {
+    if value == 42 {
         Ok(())
     } else {
         Err(PickyError(value as u8))

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.stderr
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.stderr
@@ -2,10 +2,10 @@ error[E0308]: mismatched types
   --> tests/fail/invalid_verify_with_struct_type.rs:32:10
    |
 32 | #[derive(Packable)]
-   |          ^^^^^^^^
-   |          |
-   |          expected `&u64`, found `&Picky`
-   |          arguments to this function are incorrect
+   |          ^^^^^^^^ expected `&u64`, found `&Picky`
+33 | #[packable(unpack_error = PickyError)]
+34 | #[packable(verify_with = verify)]
+   |                          ------ arguments to this function are incorrect
    |
    = note: expected reference `&u64`
               found reference `&Picky`

--- a/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.stderr
+++ b/packable/packable-derive-test/tests/fail/invalid_verify_with_struct_type.stderr
@@ -12,6 +12,6 @@ error[E0308]: mismatched types
 note: function defined here
   --> tests/fail/invalid_verify_with_struct_type.rs:24:4
    |
-24 | fn verify<const VERIFY: bool>(&value: &u64) -> Result<(), PickyError> {
-   |    ^^^^^^                     ------------
+24 | fn verify(&value: &u64) -> Result<(), PickyError> {
+   |    ^^^^^^ ------------
    = note: this error originates in the derive macro `Packable` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/packable/packable-derive-test/tests/lib.rs
+++ b/packable/packable-derive-test/tests/lib.rs
@@ -60,4 +60,4 @@ macro_rules! make_test {
 #[rustversion::stable]
 make_test!();
 #[rustversion::not(stable)]
-make_test!();
+make_test!(incorrect_tag_enum);

--- a/packable/packable-derive-test/tests/pass/error_coercion.rs
+++ b/packable/packable-derive-test/tests/pass/error_coercion.rs
@@ -31,11 +31,11 @@ impl Packable for Picky {
         self.0.pack(packer)
     }
 
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let value = u8::unpack::<_, VERIFY>(unpacker, visitor).coerce()?;
+        let value = u8::unpack(unpacker, visitor).coerce()?;
 
         if value == 42 {
             Ok(Self(value))

--- a/packable/packable-derive-test/tests/pass/verify_with_field.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field.rs
@@ -21,12 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value(value: &u8, visitor: Option<&()>) -> Result<(), PickyError> {
-    if visitor.is_none() || value == 42 {
-        Ok(())
-    } else {
-        Err(PickyError(value))
-    }
+fn verify_value(value: &u8) -> Result<(), PickyError> {
+    if value == 42 { Ok(()) } else { Err(PickyError(value)) }
 }
 
 #[derive(Packable)]

--- a/packable/packable-derive-test/tests/pass/verify_with_field.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value<const VERIFY: bool>(&value: &u8) -> Result<(), PickyError> {
-    if !VERIFY || value == 42 {
+fn verify_value(value: &u8, visitor: Option<&()>) -> Result<(), PickyError> {
+    if visitor.is_none() || value == 42 {
         Ok(())
     } else {
         Err(PickyError(value))

--- a/packable/packable-derive-test/tests/pass/verify_with_field.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field.rs
@@ -21,7 +21,7 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value(value: &u8) -> Result<(), PickyError> {
+fn verify_value(&value: &u8) -> Result<(), PickyError> {
     if value == 42 { Ok(()) } else { Err(PickyError(value)) }
 }
 

--- a/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
@@ -21,7 +21,7 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(value: &u64) -> Result<(), PickyError> {
+fn verify(&value: &u64) -> Result<(), PickyError> {
     if value == 42 {
         Ok(())
     } else {

--- a/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
@@ -21,11 +21,11 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value<const VERIFY: bool>(&value: &u8, _: &()) -> Result<(), PickyError> {
-    if !VERIFY || value == 42 {
+fn verify(value: &u64, visitor: Option<&()>) -> Result<(), PickyError> {
+    if visitor.is_none() || value == 42 {
         Ok(())
     } else {
-        Err(PickyError(value))
+        Err(PickyError(value as u8))
     }
 }
 

--- a/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
@@ -21,12 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify_value(&value: &u64) -> Result<(), PickyError> {
-    if value == 42 {
-        Ok(())
-    } else {
-        Err(PickyError(value as u8))
-    }
+fn verify_value(&value: &u8, _: &()) -> Result<(), PickyError> {
+    if value == 42 { Ok(()) } else { Err(PickyError(value)) }
 }
 
 #[derive(Packable)]

--- a/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
@@ -21,7 +21,7 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(&value: &u64) -> Result<(), PickyError> {
+fn verify_value(&value: &u64) -> Result<(), PickyError> {
     if value == 42 {
         Ok(())
     } else {

--- a/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_field_visitor.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(value: &u64, visitor: Option<&()>) -> Result<(), PickyError> {
-    if visitor.is_none() || value == 42 {
+fn verify(value: &u64) -> Result<(), PickyError> {
+    if value == 42 {
         Ok(())
     } else {
         Err(PickyError(value as u8))

--- a/packable/packable-derive-test/tests/pass/verify_with_struct.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_struct.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(value: &Picky, visitor: Option<&()>) -> Result<(), PickyError> {
-    if visitor.is_none() || value.0 == 42 {
+fn verify(value: &Picky) -> Result<(), PickyError> {
+    if value.0 == 42 {
         Ok(())
     } else {
         Err(PickyError(value.0))

--- a/packable/packable-derive-test/tests/pass/verify_with_struct.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_struct.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify<const VERIFY: bool>(value: &Picky) -> Result<(), PickyError> {
-    if !VERIFY || value.0 == 42 {
+fn verify(value: &Picky, visitor: Option<&()>) -> Result<(), PickyError> {
+    if visitor.is_none() || value.0 == 42 {
         Ok(())
     } else {
         Err(PickyError(value.0))

--- a/packable/packable-derive-test/tests/pass/verify_with_struct_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_struct_visitor.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(value: &Picky, visitor: Option<&()>) -> Result<(), PickyError> {
-    if visitor.is_none() || value.0 == 42 {
+fn verify(value: &Picky) -> Result<(), PickyError> {
+    if value.0 == 42 {
         Ok(())
     } else {
         Err(PickyError(value.0))

--- a/packable/packable-derive-test/tests/pass/verify_with_struct_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_struct_visitor.rs
@@ -21,8 +21,8 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify<const VERIFY: bool>(value: &Picky, _: &()) -> Result<(), PickyError> {
-    if !VERIFY || value.0 == 42 {
+fn verify(value: &Picky, visitor: Option<&()>) -> Result<(), PickyError> {
+    if visitor.is_none() || value.0 == 42 {
         Ok(())
     } else {
         Err(PickyError(value.0))

--- a/packable/packable-derive-test/tests/pass/verify_with_struct_visitor.rs
+++ b/packable/packable-derive-test/tests/pass/verify_with_struct_visitor.rs
@@ -21,7 +21,7 @@ impl From<Infallible> for PickyError {
     }
 }
 
-fn verify(value: &Picky) -> Result<(), PickyError> {
+fn verify(value: &Picky, _: &()) -> Result<(), PickyError> {
     if value.0 == 42 {
         Ok(())
     } else {

--- a/packable/packable-derive/CHANGELOG.md
+++ b/packable/packable-derive/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to new `Packable` trait.
+- Updated to new `Packable` trait;
 - `verify_with` function is no longer called if the visitor is `None`;
 
 ## 0.9.0 - 2023-11-17

--- a/packable/packable-derive/CHANGELOG.md
+++ b/packable/packable-derive/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.10.0 - 2024-02-08
+
+### Changed
+
+- Updated to new `Packable` trait.
+- `verify_with` function is no longer called if the visitor is `None`;
+
 ## 0.9.0 - 2023-11-17
 
 ### Changed

--- a/packable/packable-derive/CHANGELOG.md
+++ b/packable/packable-derive/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.10.0 - 2024-02-08
+## 0.10.0 - 2024-02-09
 
 ### Changed
 

--- a/packable/packable-derive/Cargo.toml
+++ b/packable/packable-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packable-derive"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 description = "Derive macro for the `packable` crate."

--- a/packable/packable-derive/src/enum_info.rs
+++ b/packable/packable-derive/src/enum_info.rs
@@ -34,20 +34,17 @@ impl EnumInfo {
         )?;
 
         let unpack_visitor = UnpackVisitorInfo::new(filtered_attrs, || {
-            let (unpack_visitor, explicit) = match data
+            let unpack_visitor = match data
                 .variants
                 .iter()
                 .next()
                 .and_then(|variant| variant.fields.iter().next())
             {
-                Some(Field { ty, .. }) => (parse_quote!(<#ty as #crate_name::Packable>::UnpackVisitor), true),
-                None => (parse_quote!(()), false),
+                Some(Field { ty, .. }) => parse_quote!(<#ty as #crate_name::Packable>::UnpackVisitor),
+                None => parse_quote!(()),
             };
 
-            Ok(UnpackVisitorInfo {
-                unpack_visitor,
-                explicit,
-            })
+            Ok(UnpackVisitorInfo { unpack_visitor })
         })?;
 
         let variants_info = data

--- a/packable/packable-derive/src/enum_info.rs
+++ b/packable/packable-derive/src/enum_info.rs
@@ -34,17 +34,20 @@ impl EnumInfo {
         )?;
 
         let unpack_visitor = UnpackVisitorInfo::new(filtered_attrs, || {
-            let unpack_visitor = match data
+            let (unpack_visitor, explicit) = match data
                 .variants
                 .iter()
                 .next()
                 .and_then(|variant| variant.fields.iter().next())
             {
-                Some(Field { ty, .. }) => parse_quote!(<#ty as #crate_name::Packable>::UnpackVisitor),
-                None => parse_quote!(()),
+                Some(Field { ty, .. }) => (parse_quote!(<#ty as #crate_name::Packable>::UnpackVisitor), true),
+                None => (parse_quote!(()), false),
             };
 
-            Ok(UnpackVisitorInfo { unpack_visitor })
+            Ok(UnpackVisitorInfo {
+                unpack_visitor,
+                explicit,
+            })
         })?;
 
         let variants_info = data

--- a/packable/packable-derive/src/fragments.rs
+++ b/packable/packable-derive/src/fragments.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Ident, Path};
 
-use crate::record_info::RecordInfo;
+use crate::{record_info::RecordInfo, unpack_visitor_info::UnpackVisitorInfo};
 
 pub(crate) struct Fragments {
     // The pattern used to destructure the record.
@@ -17,7 +17,12 @@ pub(crate) struct Fragments {
 }
 
 impl Fragments {
-    pub(crate) fn new(info: RecordInfo, verify_with: Option<Path>, crate_name: &Ident) -> Self {
+    pub(crate) fn new(
+        info: RecordInfo,
+        verify_with: Option<Path>,
+        unpack_visitor_info: &UnpackVisitorInfo,
+        crate_name: &Ident,
+    ) -> Self {
         let RecordInfo {
             path,
             fields_unpack_error_with,
@@ -27,14 +32,40 @@ impl Fragments {
             fields_type,
         } = info;
 
-        let fields_verification = fields_verify_with.into_iter().zip(fields_ident.iter()).map(|(verify_with, field_ident)| match verify_with {
-            Some(verify_with) => quote!(#verify_with(&#field_ident, visitor).map_err(#crate_name::error::UnpackError::from_packable)?;),
-            None => quote!(),
-        });
+        let fields_verification = fields_verify_with.into_iter().zip(fields_ident.iter()).map(
+            |(verify_with, field_ident)| match verify_with {
+                Some(verify_with) => if unpack_visitor_info.explicit {
+                    quote! {
+                        if let Some(visitor) = visitor {
+                            #verify_with(&#field_ident, visitor).map_err(#crate_name::error::UnpackError::from_packable)?;
+                        }
+                    }
+                } else {
+                    quote! {
+                        if visitor.is_some() {
+                            #verify_with(&#field_ident).map_err(#crate_name::error::UnpackError::from_packable)?;
+                        }
+                    }
+                },
+                None => quote!(),
+            },
+        );
 
         let verify_with = match verify_with {
             Some(verify_with) => {
-                quote!(#verify_with(&unpacked, visitor).map_err(#crate_name::error::UnpackError::from_packable)?;)
+                if unpack_visitor_info.explicit {
+                    quote! {
+                        if let Some(visitor) = visitor {
+                            #verify_with(&unpacked, visitor).map_err(#crate_name::error::UnpackError::from_packable)?;
+                        }
+                    }
+                } else {
+                    quote! {
+                        if visitor.is_some() {
+                            #verify_with(&unpacked).map_err(#crate_name::error::UnpackError::from_packable)?;
+                        }
+                    }
+                }
             }
             None => quote!(),
         };

--- a/packable/packable-derive/src/struct_info.rs
+++ b/packable/packable-derive/src/struct_info.rs
@@ -42,12 +42,34 @@ impl StructInfo {
         }
 
         let unpack_visitor = UnpackVisitorInfo::new(filtered_attrs, || {
-            let unpack_visitor = match fields.iter().next() {
-                Some(Field { ty, .. }) => parse_quote!(<#ty as #crate_name::Packable>::UnpackVisitor),
-                None => parse_quote!(()),
+            let (unpack_visitor, explicit) = match fields.iter().next() {
+                Some(Field { attrs, ty, .. }) => {
+                    let mut explicit = false;
+
+                    for attr in filter_attrs(attrs) {
+                        explicit = attr
+                            .parse_args_with(|stream: ParseStream| {
+                                let opt = parse_kv::<Path>("unpack_visitor", stream)?;
+                                if opt.is_none() {
+                                    skip_stream(stream)?;
+                                }
+                                Ok(opt)
+                            })?
+                            .is_some();
+                        if explicit {
+                            break;
+                        }
+                    }
+
+                    (parse_quote!(<#ty as #crate_name::Packable>::UnpackVisitor), explicit)
+                }
+                None => (parse_quote!(()), false),
             };
 
-            Ok(UnpackVisitorInfo { unpack_visitor })
+            Ok(UnpackVisitorInfo {
+                unpack_visitor,
+                explicit,
+            })
         })?;
 
         let inner = RecordInfo::new(path, fields, &unpack_error.with)?;

--- a/packable/packable-derive/src/trait_impl.rs
+++ b/packable/packable-derive/src/trait_impl.rs
@@ -29,7 +29,8 @@ impl TraitImpl {
                 let unpack_error = info.unpack_error.unpack_error.clone().into_token_stream();
                 let unpack_visitor = info.unpack_visitor.unpack_visitor.clone().into_token_stream();
 
-                let Fragments { pattern, pack, unpack } = Fragments::new(info.inner, info.verify_with, &crate_name);
+                let Fragments { pattern, pack, unpack } =
+                    Fragments::new(info.inner, info.verify_with, &info.unpack_visitor, &crate_name);
 
                 Ok(Self {
                     ident: input.ident,
@@ -65,7 +66,8 @@ impl TraitImpl {
                 for (index, VariantInfo { tag, inner }) in info.variants_info.into_iter().enumerate() {
                     let variant_ident = inner.path.segments.last().unwrap().clone();
 
-                    let Fragments { pattern, pack, unpack } = Fragments::new(inner, None, &crate_name);
+                    let Fragments { pattern, pack, unpack } =
+                        Fragments::new(inner, None, &info.unpack_visitor, &crate_name);
 
                     // @pvdrz: The span here is very important, otherwise the compiler won't detect
                     // unreachable patterns in the generated code for some reason. I think this is related

--- a/packable/packable-derive/src/unpack_visitor_info.rs
+++ b/packable/packable-derive/src/unpack_visitor_info.rs
@@ -10,7 +10,6 @@ use crate::parse::{parse_kv, skip_stream};
 
 pub(crate) struct UnpackVisitorInfo {
     pub(crate) unpack_visitor: syn::Type,
-    pub(crate) explicit: bool,
 }
 
 struct Type(syn::Type);
@@ -35,10 +34,7 @@ impl UnpackVisitorInfo {
             let opt_info =
                 attr.parse_args_with(
                     |stream: ParseStream| match parse_kv::<Type>("unpack_visitor", stream)? {
-                        Some(Type(unpack_visitor)) => Ok(Some(Self {
-                            unpack_visitor,
-                            explicit: true,
-                        })),
+                        Some(Type(unpack_visitor)) => Ok(Some(Self { unpack_visitor })),
                         None => {
                             skip_stream(stream)?;
                             Ok(None)

--- a/packable/packable-derive/src/unpack_visitor_info.rs
+++ b/packable/packable-derive/src/unpack_visitor_info.rs
@@ -10,6 +10,7 @@ use crate::parse::{parse_kv, skip_stream};
 
 pub(crate) struct UnpackVisitorInfo {
     pub(crate) unpack_visitor: syn::Type,
+    pub(crate) explicit: bool,
 }
 
 struct Type(syn::Type);
@@ -34,7 +35,10 @@ impl UnpackVisitorInfo {
             let opt_info =
                 attr.parse_args_with(
                     |stream: ParseStream| match parse_kv::<Type>("unpack_visitor", stream)? {
-                        Some(Type(unpack_visitor)) => Ok(Some(Self { unpack_visitor })),
+                        Some(Type(unpack_visitor)) => Ok(Some(Self {
+                            unpack_visitor,
+                            explicit: true,
+                        })),
                         None => {
                             skip_stream(stream)?;
                             Ok(None)

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
+## 0.11.0 - 2024-02-08
+
+### Added
+
+- `Packable::unpack_inner`, `Packable::unpack_verified`, and `Packable::unpack_unverified`;
+
+### Changed
+
+- Removed `Default` bound from `Packable::UnpackVisitor`;
+- Replaced `const VERIFY` in `Packable::unpack` with `Option<&Self::UnpackVisitor>`, which can be checked instead;
+- Renamed `PackableExt::unpack_verified` and `unpack_unverified` to `unpack_bytes_verified` and `unpack_bytes_unverified`;
+
 ## 0.10.1 - 2024-01-08
 
 ### Added

--- a/packable/packable/CHANGELOG.md
+++ b/packable/packable/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security -->
 
-## 0.11.0 - 2024-02-08
+## 0.11.0 - 2024-02-09
 
 ### Added
 

--- a/packable/packable/Cargo.toml
+++ b/packable/packable/Cargo.toml
@@ -29,4 +29,5 @@ hashbrown = { version = "0.14.3", default-features = false, features = [
 primitive-types = { version = "0.12.2", default-features = false, optional = true }
 serde = { version = "1.0.195", default-features = false, features = [
     "derive",
+    "alloc"
 ], optional = true }

--- a/packable/packable/Cargo.toml
+++ b/packable/packable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "packable"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["IOTA Stiftung"]
 edition = "2021"
 description = "A crate for packing and unpacking binary representations."
@@ -20,7 +20,7 @@ usize = []
 autocfg = { version = "1.1.0", default-features = false }
 
 [dependencies]
-packable-derive = { version = "=0.9.0", path = "../packable-derive", default-features = false }
+packable-derive = { version = "=0.10.0", path = "../packable-derive", default-features = false }
 
 hashbrown = { version = "0.14.3", default-features = false, features = [
     "ahash",

--- a/packable/packable/src/packable/array.rs
+++ b/packable/packable/src/packable/array.rs
@@ -25,9 +25,9 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         if TypeId::of::<T>() == TypeId::of::<u8>() {
             let mut bytes = [0u8; N];
@@ -40,7 +40,7 @@ impl<T: Packable, const N: usize> Packable for [T; N] {
             let mut array = unsafe { MaybeUninit::<[MaybeUninit<T>; N]>::uninit().assume_init() };
 
             for item in array.iter_mut() {
-                let unpacked = T::unpack::<_, VERIFY>(unpacker, visitor)?;
+                let unpacked = T::unpack(unpacker, visitor)?;
 
                 // Safety: each `item` is only visited once so we are never overwriting nor dropping values that are
                 // already initialized.

--- a/packable/packable/src/packable/bool.rs
+++ b/packable/packable/src/packable/bool.rs
@@ -22,10 +22,10 @@ impl Packable for bool {
 
     /// Booleans are unpacked if the byte used to represent them is non-zero.
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(u8::unpack::<_, VERIFY>(unpacker, visitor).coerce()? != 0)
+        Ok(u8::unpack(unpacker, visitor).coerce()? != 0)
     }
 }

--- a/packable/packable/src/packable/bounded.rs
+++ b/packable/packable/src/packable/bounded.rs
@@ -41,8 +41,8 @@ macro_rules! bounded {
                 self.0
             }
 
-            fn verify(value: &$ty, visitor: Option<&()>) -> Result<(), $invalid_error<MIN, MAX>> {
-                if visitor.is_some() && !(MIN..=MAX).contains(value) {
+            fn verify(value: &$ty) -> Result<(), $invalid_error<MIN, MAX>> {
+                if !(MIN..=MAX).contains(value) {
                     Err($invalid_error(*value))
                 } else {
                     Ok(())
@@ -67,7 +67,7 @@ macro_rules! bounded {
             type Error = $invalid_error<MIN, MAX>;
 
             fn try_from(value: $ty) -> Result<Self, Self::Error> {
-                // Self::verify(&value, Some(&()))?;
+                Self::verify(&value)?;
                 Ok(Self(value))
             }
         }
@@ -113,7 +113,7 @@ macro_rules! bounded {
         }
 
         #[doc = concat!("Error encountered when attempting to convert a [`usize`] into a [`",
-                                                                stringify!($wrapper),"`].")]
+                                                                                        stringify!($wrapper),"`].")]
         #[derive(Debug, Clone, Copy, PartialEq, Eq)]
         pub enum $try_error<const MIN: $ty, const MAX: $ty> {
             #[doc = concat!("The `usize` could be converted into a [`", stringify!($ty),"`] but it is not within the

--- a/packable/packable/src/packable/box.rs
+++ b/packable/packable/src/packable/box.rs
@@ -60,7 +60,7 @@ impl<T: Packable> Packable for Box<[T]> {
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
-        let len = u64::unpack(unpacker, None)
+        let len = u64::unpack_inner(unpacker, visitor)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(Self::UnpackError::Prefix(err)))?;

--- a/packable/packable/src/packable/box.rs
+++ b/packable/packable/src/packable/box.rs
@@ -22,11 +22,11 @@ impl<T: Packable> Packable for Box<T> {
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        Ok(Box::new(T::unpack::<_, VERIFY>(unpacker, visitor)?))
+        Ok(Box::new(T::unpack(unpacker, visitor)?))
     }
 }
 
@@ -54,13 +54,13 @@ impl<T: Packable> Packable for Box<[T]> {
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
-        let len = u64::unpack::<_, VERIFY>(unpacker, &())
+        let len = u64::unpack(unpacker, None)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(Self::UnpackError::Prefix(err)))?;
@@ -74,7 +74,7 @@ impl<T: Packable> Packable for Box<[T]> {
             let mut vec = Vec::with_capacity(len);
 
             for _ in 0..len {
-                let item = T::unpack::<_, VERIFY>(unpacker, visitor).map_packable_err(Self::UnpackError::Item)?;
+                let item = T::unpack(unpacker, visitor).map_packable_err(Self::UnpackError::Item)?;
                 vec.push(item);
             }
 

--- a/packable/packable/src/packable/map.rs
+++ b/packable/packable/src/packable/map.rs
@@ -143,7 +143,7 @@ where
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
-        let len = u64::unpack(unpacker, None)
+        let len = u64::unpack_inner(unpacker, visitor)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(UnpackMapError::Prefix(err)))?;
@@ -151,7 +151,7 @@ where
         let mut map = HashMap::<K, V>::with_capacity(len);
 
         for _ in 0..len {
-            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
+            let key = K::unpack_inner(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -198,7 +198,7 @@ where
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
-        let len = u64::unpack(unpacker, None)
+        let len = u64::unpack_inner(unpacker, visitor)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(UnpackMapError::Prefix(err).into()))?;
@@ -206,7 +206,7 @@ where
         let mut map = BTreeMap::<K, V>::new();
 
         for _ in 0..len {
-            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
+            let key = K::unpack_inner(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 

--- a/packable/packable/src/packable/map.rs
+++ b/packable/packable/src/packable/map.rs
@@ -137,13 +137,13 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
-        let len = u64::unpack::<_, VERIFY>(unpacker, &())
+        let len = u64::unpack(unpacker, None)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(UnpackMapError::Prefix(err)))?;
@@ -151,7 +151,7 @@ where
         let mut map = HashMap::<K, V>::with_capacity(len);
 
         for _ in 0..len {
-            let key = K::unpack::<_, VERIFY>(unpacker, visitor.borrow())
+            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -159,7 +159,7 @@ where
                 return Err(UnpackError::Packable(UnpackMapError::DuplicateKey(key)));
             }
 
-            let value = V::unpack::<_, VERIFY>(unpacker, visitor)
+            let value = V::unpack(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Value)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -192,13 +192,13 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
-        let len = u64::unpack::<_, VERIFY>(unpacker, &())
+        let len = u64::unpack(unpacker, None)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(UnpackMapError::Prefix(err).into()))?;
@@ -206,7 +206,7 @@ where
         let mut map = BTreeMap::<K, V>::new();
 
         for _ in 0..len {
-            let key = K::unpack::<_, VERIFY>(unpacker, visitor.borrow())
+            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -224,7 +224,7 @@ where
                 }
             }
 
-            let value = V::unpack::<_, VERIFY>(unpacker, visitor)
+            let value = V::unpack(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Value)
                 .map_packable_err(Self::UnpackError::from)?;
 

--- a/packable/packable/src/packable/num.rs
+++ b/packable/packable/src/packable/num.rs
@@ -17,9 +17,9 @@ macro_rules! impl_packable_for_num {
             }
 
             #[inline]
-            fn unpack<U: Unpacker, const VERIFY: bool>(
+            fn unpack<U: Unpacker>(
                 unpacker: &mut U,
-                (): &Self::UnpackVisitor,
+                _: Option<&Self::UnpackVisitor>,
             ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                 let mut bytes = [0u8; core::mem::size_of::<Self>()];
                 unpacker.unpack_bytes(&mut bytes)?;
@@ -63,12 +63,12 @@ impl Packable for usize {
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
-        Self::try_from(u64::unpack::<_, VERIFY>(unpacker, visitor).coerce()?).map_err(UnpackError::Packable)
+        Self::try_from(u64::unpack(unpacker, visitor).coerce()?).map_err(UnpackError::Packable)
     }
 }
 
@@ -83,11 +83,11 @@ impl Packable for isize {
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
-        Self::try_from(i64::unpack::<_, VERIFY>(unpacker, visitor).coerce()?).map_err(UnpackError::Packable)
+        Self::try_from(i64::unpack(unpacker, visitor).coerce()?).map_err(UnpackError::Packable)
     }
 }

--- a/packable/packable/src/packable/option.rs
+++ b/packable/packable/src/packable/option.rs
@@ -58,7 +58,7 @@ impl<T: Packable> Packable for Option<T> {
         unpacker: &mut U,
         visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        match u8::unpack(unpacker, None).coerce()? {
+        match u8::unpack_inner(unpacker, visitor).coerce()? {
             0 => Ok(None),
             1 => Ok(Some(
                 T::unpack(unpacker, visitor).map_packable_err(UnpackOptionError::Inner)?,

--- a/packable/packable/src/packable/option.rs
+++ b/packable/packable/src/packable/option.rs
@@ -54,14 +54,14 @@ impl<T: Packable> Packable for Option<T> {
         }
     }
 
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        match u8::unpack::<_, VERIFY>(unpacker, &()).coerce()? {
+        match u8::unpack(unpacker, None).coerce()? {
             0 => Ok(None),
             1 => Ok(Some(
-                T::unpack::<_, VERIFY>(unpacker, visitor).map_packable_err(UnpackOptionError::Inner)?,
+                T::unpack(unpacker, visitor).map_packable_err(UnpackOptionError::Inner)?,
             )),
             n => Err(UnpackError::Packable(Self::UnpackError::UnknownTag(n))),
         }

--- a/packable/packable/src/packable/prefix/boxed.rs
+++ b/packable/packable/src/packable/prefix/boxed.rs
@@ -114,11 +114,11 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let vec: Vec<T> = VecPrefix::<T, B>::unpack::<_, VERIFY>(unpacker, visitor)?.into();
+        let vec: Vec<T> = VecPrefix::<T, B>::unpack(unpacker, visitor)?.into();
 
         Ok(Self {
             inner: vec.into_boxed_slice(),

--- a/packable/packable/src/packable/prefix/btreeset.rs
+++ b/packable/packable/src/packable/prefix/btreeset.rs
@@ -113,7 +113,7 @@ where
         use crate::error::UnpackErrorExt;
 
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack(unpacker, None)
+        let len = B::unpack_inner(unpacker, visitor)
             .map_packable_err(UnpackSetError::Prefix)
             .map_packable_err(Self::UnpackError::from)?
             .into();

--- a/packable/packable/src/packable/prefix/btreeset.rs
+++ b/packable/packable/src/packable/prefix/btreeset.rs
@@ -106,14 +106,14 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack::<_, VERIFY>(unpacker, &())
+        let len = B::unpack(unpacker, None)
             .map_packable_err(UnpackSetError::Prefix)
             .map_packable_err(Self::UnpackError::from)?
             .into();
@@ -121,7 +121,7 @@ where
         let mut set = BTreeSet::<T>::new();
 
         for _ in B::Bounds::default()..len {
-            let item = T::unpack::<_, VERIFY>(unpacker, visitor)
+            let item = T::unpack(unpacker, visitor)
                 .map_packable_err(UnpackSetError::Item)
                 .map_packable_err(Self::UnpackError::from)?;
 

--- a/packable/packable/src/packable/prefix/map.rs
+++ b/packable/packable/src/packable/prefix/map.rs
@@ -111,14 +111,14 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack::<_, VERIFY>(unpacker, &())
+        let len = B::unpack(unpacker, None)
             .map_packable_err(UnpackMapError::Prefix)
             .map_packable_err(Self::UnpackError::from)?
             .into();
@@ -126,7 +126,7 @@ where
         let mut map = HashMap::<K, V>::new();
 
         for _ in B::Bounds::default()..len {
-            let key = K::unpack::<_, VERIFY>(unpacker, visitor.borrow())
+            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -134,7 +134,7 @@ where
                 return Err(UnpackError::Packable(UnpackMapError::DuplicateKey(key)));
             }
 
-            let value = V::unpack::<_, VERIFY>(unpacker, visitor)
+            let value = V::unpack(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Value)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -236,14 +236,14 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         use crate::error::UnpackErrorExt;
 
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack::<_, VERIFY>(unpacker, &())
+        let len = B::unpack(unpacker, None)
             .map_packable_err(UnpackMapError::Prefix)
             .map_packable_err(Self::UnpackError::from)?
             .into();
@@ -251,7 +251,7 @@ where
         let mut map = BTreeMap::<K, V>::new();
 
         for _ in B::Bounds::default()..len {
-            let key = K::unpack::<_, VERIFY>(unpacker, visitor.borrow())
+            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -269,7 +269,7 @@ where
                 }
             }
 
-            let value = V::unpack::<_, VERIFY>(unpacker, visitor)
+            let value = V::unpack(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Value)
                 .map_packable_err(Self::UnpackError::from)?;
 

--- a/packable/packable/src/packable/prefix/map.rs
+++ b/packable/packable/src/packable/prefix/map.rs
@@ -118,7 +118,7 @@ where
         use crate::error::UnpackErrorExt;
 
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack(unpacker, None)
+        let len = B::unpack_inner(unpacker, visitor)
             .map_packable_err(UnpackMapError::Prefix)
             .map_packable_err(Self::UnpackError::from)?
             .into();
@@ -126,7 +126,7 @@ where
         let mut map = HashMap::<K, V>::new();
 
         for _ in B::Bounds::default()..len {
-            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
+            let key = K::unpack_inner(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 
@@ -243,7 +243,7 @@ where
         use crate::error::UnpackErrorExt;
 
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack(unpacker, None)
+        let len = B::unpack_inner(unpacker, visitor)
             .map_packable_err(UnpackMapError::Prefix)
             .map_packable_err(Self::UnpackError::from)?
             .into();
@@ -251,7 +251,7 @@ where
         let mut map = BTreeMap::<K, V>::new();
 
         for _ in B::Bounds::default()..len {
-            let key = K::unpack(unpacker, visitor.map(Borrow::borrow))
+            let key = K::unpack_inner(unpacker, visitor)
                 .map_packable_err(UnpackMapError::Key)
                 .map_packable_err(Self::UnpackError::from)?;
 

--- a/packable/packable/src/packable/prefix/string.rs
+++ b/packable/packable/src/packable/prefix/string.rs
@@ -101,12 +101,12 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack::<_, VERIFY>(unpacker, visitor)
+        let len = B::unpack(unpacker, visitor)
             .map_packable_err(UnpackPrefixError::Prefix)?
             .into();
 

--- a/packable/packable/src/packable/prefix/vec.rs
+++ b/packable/packable/src/packable/prefix/vec.rs
@@ -115,7 +115,7 @@ where
         visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack(unpacker, None)
+        let len = B::unpack_inner(unpacker, visitor)
             .map_packable_err(UnpackPrefixError::Prefix)?
             .into();
 

--- a/packable/packable/src/packable/prefix/vec.rs
+++ b/packable/packable/src/packable/prefix/vec.rs
@@ -110,12 +110,12 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
         // The length of any dynamically-sized sequence must be prefixed.
-        let len = B::unpack::<_, VERIFY>(unpacker, &())
+        let len = B::unpack(unpacker, None)
             .map_packable_err(UnpackPrefixError::Prefix)?
             .into();
 
@@ -143,7 +143,7 @@ where
             let mut inner = Vec::with_capacity(len.try_into().unwrap_or(0));
 
             for _ in B::Bounds::default()..len {
-                let item = T::unpack::<_, VERIFY>(unpacker, visitor).map_packable_err(Self::UnpackError::Item)?;
+                let item = T::unpack(unpacker, visitor).map_packable_err(Self::UnpackError::Item)?;
                 inner.push(item);
             }
 

--- a/packable/packable/src/packable/primitive_types.rs
+++ b/packable/packable/src/packable/primitive_types.rs
@@ -17,10 +17,10 @@ impl Packable for U256 {
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        <[u64; 4]>::unpack::<_, VERIFY>(unpacker, visitor).map(Self)
+        <[u64; 4]>::unpack(unpacker, visitor).map(Self)
     }
 }

--- a/packable/packable/src/packable/set.rs
+++ b/packable/packable/src/packable/set.rs
@@ -122,13 +122,13 @@ mod btreeset {
         }
 
         #[inline]
-        fn unpack<U: Unpacker, const VERIFY: bool>(
+        fn unpack<U: Unpacker>(
             unpacker: &mut U,
-            visitor: &Self::UnpackVisitor,
+            visitor: Option<&Self::UnpackVisitor>,
         ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
             use crate::error::UnpackErrorExt;
 
-            let len = u64::unpack::<_, VERIFY>(unpacker, &())
+            let len = u64::unpack(unpacker, None)
                 .coerce()?
                 .try_into()
                 .map_err(|err| UnpackError::Packable(UnpackSetError::Prefix(err).into()))?;
@@ -136,7 +136,7 @@ mod btreeset {
             let mut set = BTreeSet::<T>::new();
 
             for _ in 0..len {
-                let item = T::unpack::<_, VERIFY>(unpacker, visitor)
+                let item = T::unpack(unpacker, visitor)
                     .map_packable_err(UnpackSetError::Item)
                     .map_packable_err(Self::UnpackError::from)?;
 

--- a/packable/packable/src/packable/set.rs
+++ b/packable/packable/src/packable/set.rs
@@ -128,7 +128,7 @@ mod btreeset {
         ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
             use crate::error::UnpackErrorExt;
 
-            let len = u64::unpack(unpacker, None)
+            let len = u64::unpack_inner(unpacker, visitor)
                 .coerce()?
                 .try_into()
                 .map_err(|err| UnpackError::Packable(UnpackSetError::Prefix(err).into()))?;

--- a/packable/packable/src/packable/string.rs
+++ b/packable/packable/src/packable/string.rs
@@ -32,11 +32,11 @@ impl Packable for String {
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let bytes = Vec::<u8>::unpack::<_, VERIFY>(unpacker, visitor)
+        let bytes = Vec::<u8>::unpack(unpacker, visitor)
             .map_packable_err(|err| UnpackPrefixError::Prefix(err.into_prefix_err()))?;
 
         String::from_utf8(bytes).map_err(|e| UnpackError::Packable(Self::UnpackError::Item(e)))

--- a/packable/packable/src/packable/tuple.rs
+++ b/packable/packable/src/packable/tuple.rs
@@ -28,13 +28,13 @@ macro_rules! tuple_impls {
                     Ok(())
                 }
 
-                fn unpack<U: Unpacker, const VERIFY: bool>(
+                fn unpack<U: Unpacker>(
                     unpacker: &mut U,
-                    visitor: &Self::UnpackVisitor,
+                    visitor: Option<&Self::UnpackVisitor>,
                 ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                     Ok((
-                            <$FirstT>::unpack::<_, VERIFY>(unpacker, visitor)?,
-                            $( (<$T>::unpack::<_, VERIFY>(unpacker, visitor.borrow()).map_packable_err(Into::into))?,)*
+                            <$FirstT>::unpack(unpacker, visitor)?,
+                            $( (<$T>::unpack(unpacker, visitor.map(core::borrow::Borrow::borrow)).map_packable_err(Into::into))?,)*
                        ))
                 }
             }

--- a/packable/packable/src/packable/tuple.rs
+++ b/packable/packable/src/packable/tuple.rs
@@ -34,7 +34,7 @@ macro_rules! tuple_impls {
                 ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
                     Ok((
                             <$FirstT>::unpack(unpacker, visitor)?,
-                            $( (<$T>::unpack(unpacker, visitor.map(core::borrow::Borrow::borrow)).map_packable_err(Into::into))?,)*
+                            $( (<$T>::unpack_inner(unpacker, visitor).map_packable_err(Into::into))?,)*
                        ))
                 }
             }

--- a/packable/packable/src/packable/vec.rs
+++ b/packable/packable/src/packable/vec.rs
@@ -40,11 +40,11 @@ where
     }
 
     #[inline]
-    fn unpack<U: Unpacker, const VERIFY: bool>(
+    fn unpack<U: Unpacker>(
         unpacker: &mut U,
-        visitor: &Self::UnpackVisitor,
+        visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let len = u64::unpack::<_, VERIFY>(unpacker, &())
+        let len = u64::unpack(unpacker, None)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(UnpackPrefixError::Prefix(err)))?;
@@ -58,7 +58,7 @@ where
             let mut vec = Vec::with_capacity(len);
 
             for _ in 0..len {
-                let item = T::unpack::<_, VERIFY>(unpacker, visitor).map_packable_err(Self::UnpackError::Item)?;
+                let item = T::unpack(unpacker, visitor).map_packable_err(Self::UnpackError::Item)?;
                 vec.push(item);
             }
 

--- a/packable/packable/src/packable/vec.rs
+++ b/packable/packable/src/packable/vec.rs
@@ -44,7 +44,7 @@ where
         unpacker: &mut U,
         visitor: Option<&Self::UnpackVisitor>,
     ) -> Result<Self, UnpackError<Self::UnpackError, U::Error>> {
-        let len = u64::unpack(unpacker, None)
+        let len = u64::unpack_inner(unpacker, visitor)
             .coerce()?
             .try_into()
             .map_err(|err| UnpackError::Packable(UnpackPrefixError::Prefix(err)))?;

--- a/packable/packable/tests/bool.rs
+++ b/packable/packable/tests/bool.rs
@@ -16,7 +16,7 @@ fn packable_bool_packed_non_zero_bytes_are_truthy() {
     let mut packer = Vec::default();
     42u8.pack(&mut packer).unwrap();
 
-    let is_true = bool::unpack_verified(packer.as_slice(), &()).unwrap();
+    let is_true = bool::unpack_bytes_verified(packer.as_slice(), &()).unwrap();
 
     assert!(is_true);
 }

--- a/packable/packable/tests/bounded.rs
+++ b/packable/packable/tests/bounded.rs
@@ -51,7 +51,7 @@ macro_rules! impl_packable_test_for_bounded_integer {
         #[test]
         fn $packable_invalid_name() {
             let bytes = vec![0u8; core::mem::size_of::<$wrapped>()];
-            let unpacked = <$wrapper>::unpack_verified(&bytes, &());
+            let unpacked = <$wrapper>::unpack_bytes_verified(&bytes, &());
 
             assert!(matches!(unpacked, Err(UnpackError::Packable($error(0)))))
         }

--- a/packable/packable/tests/boxed_slice_prefix.rs
+++ b/packable/packable/tests/boxed_slice_prefix.rs
@@ -73,7 +73,7 @@ macro_rules! impl_packable_test_for_bounded_boxed_slice_prefix {
             let mut bytes = vec![0u8; LEN + 1].into_boxed_slice();
             bytes[0] = LEN as u8;
 
-            let prefixed = BoxedSlicePrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = BoxedSlicePrefix::<u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             const LEN_AS_TY: $ty = LEN as $ty;
 

--- a/packable/packable/tests/btreemap.rs
+++ b/packable/packable/tests/btreemap.rs
@@ -34,7 +34,7 @@ fn invalid_duplicate() {
             .chain(bytes.into_iter().flat_map(|(k, v)| [k, v])),
     );
 
-    let prefixed = BTreeMap::<u8, u8>::unpack_verified(bytes, &());
+    let prefixed = BTreeMap::<u8, u8>::unpack_bytes_verified(bytes, &());
 
     assert!(matches!(
         prefixed,
@@ -55,7 +55,7 @@ fn invalid_unordered() {
             .chain(bytes.into_iter().flat_map(|(k, v)| [k, v])),
     );
 
-    let prefixed = BTreeMap::<u8, u8>::unpack_verified(bytes, &());
+    let prefixed = BTreeMap::<u8, u8>::unpack_bytes_verified(bytes, &());
 
     assert!(matches!(
         prefixed,

--- a/packable/packable/tests/btreemap_prefix.rs
+++ b/packable/packable/tests/btreemap_prefix.rs
@@ -63,7 +63,7 @@ macro_rules! impl_packable_test_for_btreemap_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeMapPrefix::<u8, u8, $ty>::unpack_verified(bytes, &());
+            let prefixed = BTreeMapPrefix::<u8, u8, $ty>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -85,7 +85,7 @@ macro_rules! impl_packable_test_for_btreemap_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeMapPrefix::<u8, u8, $ty>::unpack_verified(bytes, &());
+            let prefixed = BTreeMapPrefix::<u8, u8, $ty>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -128,7 +128,7 @@ macro_rules! impl_packable_test_for_bounded_btreemap_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(core::iter::repeat(0).take(2 * (LEN + 1))));
 
-            let prefixed = BTreeMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = BTreeMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -149,7 +149,7 @@ macro_rules! impl_packable_test_for_bounded_btreemap_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = BTreeMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -171,7 +171,7 @@ macro_rules! impl_packable_test_for_bounded_btreemap_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = BTreeMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,

--- a/packable/packable/tests/btreeset.rs
+++ b/packable/packable/tests/btreeset.rs
@@ -26,7 +26,7 @@ fn invalid_duplicate() {
     let bytes = [1, 2, 3, 3, 4];
     let bytes = Vec::from_iter(bytes.len().to_le_bytes().into_iter().chain(bytes));
 
-    let prefixed = BTreeSet::<u8>::unpack_verified(bytes, &());
+    let prefixed = BTreeSet::<u8>::unpack_bytes_verified(bytes, &());
 
     println!("{prefixed:?}");
 
@@ -43,7 +43,7 @@ fn invalid_unordered() {
     let bytes = [1, 2, 4, 3];
     let bytes = Vec::from_iter(bytes.len().to_le_bytes().into_iter().chain(bytes));
 
-    let prefixed = BTreeSet::<u8>::unpack_verified(bytes, &());
+    let prefixed = BTreeSet::<u8>::unpack_bytes_verified(bytes, &());
 
     assert!(matches!(
         prefixed,

--- a/packable/packable/tests/btreeset_prefix.rs
+++ b/packable/packable/tests/btreeset_prefix.rs
@@ -63,7 +63,7 @@ macro_rules! impl_packable_test_for_btreeset_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeSetPrefix::<u8, $ty>::unpack_verified(bytes, &());
+            let prefixed = BTreeSetPrefix::<u8, $ty>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -83,7 +83,7 @@ macro_rules! impl_packable_test_for_btreeset_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeSetPrefix::<u8, $ty>::unpack_verified(bytes, &());
+            let prefixed = BTreeSetPrefix::<u8, $ty>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -126,7 +126,7 @@ macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(core::iter::repeat(0).take(LEN + 1)));
 
-            let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -147,7 +147,7 @@ macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -167,7 +167,7 @@ macro_rules! impl_packable_test_for_bounded_btreeset_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = BTreeSetPrefix::<u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,

--- a/packable/packable/tests/common/mod.rs
+++ b/packable/packable/tests/common/mod.rs
@@ -60,7 +60,7 @@ where
     let mut packer = IoPacker::new(Vec::new());
     packable.pack(&mut packer).unwrap();
     let mut unpacker = IoUnpacker::new(packer.as_slice());
-    let unpacked = P::unpack::<_, true>(&mut unpacker, &()).unwrap();
+    let unpacked = P::unpack(&mut unpacker, None).unwrap();
     assert_eq!(packable, &unpacked);
 
     generic_test_pack_to_slice_unpack_verified(packable);

--- a/packable/packable/tests/common/mod.rs
+++ b/packable/packable/tests/common/mod.rs
@@ -60,7 +60,7 @@ where
     let mut packer = IoPacker::new(Vec::new());
     packable.pack(&mut packer).unwrap();
     let mut unpacker = IoUnpacker::new(packer.as_slice());
-    let unpacked = P::unpack(&mut unpacker, None).unwrap();
+    let unpacked = P::unpack(&mut unpacker, Some(&())).unwrap();
     assert_eq!(packable, &unpacked);
 
     generic_test_pack_to_slice_unpack_verified(packable);

--- a/packable/packable/tests/common/mod.rs
+++ b/packable/packable/tests/common/mod.rs
@@ -19,7 +19,7 @@ where
     let mut packer = SlicePacker::new(&mut vec);
     packable.pack(&mut packer).unwrap();
 
-    let unpacked = P::unpack_verified(&vec, &()).unwrap();
+    let unpacked = P::unpack_bytes_verified(&vec, &()).unwrap();
 
     assert_eq!(packable, &unpacked);
 
@@ -35,7 +35,7 @@ where
     P::UnpackError: Debug,
 {
     let vec = packable.pack_to_vec();
-    let unpacked = P::unpack_verified(&vec, &()).unwrap();
+    let unpacked = P::unpack_bytes_verified(&vec, &()).unwrap();
 
     assert_eq!(packable, &unpacked);
     assert_eq!(packable.packed_len(), vec.len());
@@ -52,7 +52,7 @@ where
 
     let mut vec = Vec::new();
     packable.pack(&mut vec).unwrap();
-    let unpacked = P::unpack_verified(vec.as_slice(), &()).unwrap();
+    let unpacked = P::unpack_bytes_verified(vec.as_slice(), &()).unwrap();
     assert_eq!(packable, &unpacked);
 
     // Tests for `Read` and `Write`

--- a/packable/packable/tests/counter.rs
+++ b/packable/packable/tests/counter.rs
@@ -19,7 +19,7 @@ fn option_counter() {
     let packer = packer.into_inner();
     let mut unpacker = CounterUnpacker::new(SliceUnpacker::new(packer.as_slice()));
 
-    let unpacked_value = Option::<u32>::unpack::<_, true>(&mut unpacker, &()).unwrap();
+    let unpacked_value = Option::<u32>::unpack(&mut unpacker, None).unwrap();
     assert_eq!(unpacked_value.packed_len(), unpacker.counter());
     assert_eq!(unpacker.counter(), unpacker.read_bytes().unwrap());
     assert_eq!(value, unpacked_value);

--- a/packable/packable/tests/counter.rs
+++ b/packable/packable/tests/counter.rs
@@ -19,7 +19,7 @@ fn option_counter() {
     let packer = packer.into_inner();
     let mut unpacker = CounterUnpacker::new(SliceUnpacker::new(packer.as_slice()));
 
-    let unpacked_value = Option::<u32>::unpack(&mut unpacker, None).unwrap();
+    let unpacked_value = Option::<u32>::unpack_verified(&mut unpacker, &()).unwrap();
     assert_eq!(unpacked_value.packed_len(), unpacker.counter());
     assert_eq!(unpacker.counter(), unpacker.read_bytes().unwrap());
     assert_eq!(value, unpacked_value);

--- a/packable/packable/tests/map.rs
+++ b/packable/packable/tests/map.rs
@@ -29,7 +29,7 @@ fn invalid_duplicate() {
             .chain(bytes.into_iter().flat_map(|(k, v)| [k, v])),
     );
 
-    let prefixed = HashMap::<u8, u8>::unpack_verified(bytes, &());
+    let prefixed = HashMap::<u8, u8>::unpack_bytes_verified(bytes, &());
 
     assert!(matches!(
         prefixed,

--- a/packable/packable/tests/map_prefix.rs
+++ b/packable/packable/tests/map_prefix.rs
@@ -61,7 +61,7 @@ macro_rules! impl_packable_test_for_map_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = HashMapPrefix::<u8, u8, $ty>::unpack_verified(bytes, &());
+            let prefixed = HashMapPrefix::<u8, u8, $ty>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -105,7 +105,7 @@ macro_rules! impl_packable_test_for_bounded_map_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(core::iter::repeat(0).take(2 * (LEN + 1))));
 
-            let prefixed = HashMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = HashMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,
@@ -126,7 +126,7 @@ macro_rules! impl_packable_test_for_bounded_map_prefix {
 
             let bytes = Vec::from_iter(LEN_AS_TY.to_le_bytes().into_iter().chain(bytes));
 
-            let prefixed = HashMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = HashMapPrefix::<u8, u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             assert!(matches!(
                 prefixed,

--- a/packable/packable/tests/string_prefix.rs
+++ b/packable/packable/tests/string_prefix.rs
@@ -68,7 +68,7 @@ macro_rules! impl_packable_test_for_bounded_string_prefix {
             let mut bytes = vec![0; LEN + 1];
             bytes[0] = LEN as u8;
 
-            let prefixed = StringPrefix::<$bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = StringPrefix::<$bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             const LEN_AS_TY: $ty = LEN as $ty;
 

--- a/packable/packable/tests/vec_prefix.rs
+++ b/packable/packable/tests/vec_prefix.rs
@@ -68,7 +68,7 @@ macro_rules! impl_packable_test_for_bounded_vec_prefix {
             let mut bytes = vec![0u8; LEN + 1];
             bytes[0] = LEN as u8;
 
-            let prefixed = VecPrefix::<u8, $bounded<$min, $max>>::unpack_verified(bytes, &());
+            let prefixed = VecPrefix::<u8, $bounded<$min, $max>>::unpack_bytes_verified(bytes, &());
 
             const LEN_AS_TY: $ty = LEN as $ty;
 


### PR DESCRIPTION
## Description

This PR removes the `Default` bound from the `Packable::Visitor`. As a consequence, the visitor must be optional in the trait. Users can now check whether the visitor is `Some` to validate their data, so the `const VERIFY` generic is no longer useful, thus it has been removed.